### PR TITLE
manifests: update priority and image pull policy

### DIFF
--- a/manifests/0000_09_machine-approver-04-deployment.yaml
+++ b/manifests/0000_09_machine-approver-04-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: machine-approver-controller
         image: docker.io/openshift/origin-cluster-machine-approver:v4.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/usr/bin/machine-approver", "--logtostderr", "-v", "3"]
         env:
         - name: KUBERNETES_SERVICE_PORT

--- a/manifests/0000_09_machine-approver-04-deployment.yaml
+++ b/manifests/0000_09_machine-approver-04-deployment.yaml
@@ -32,5 +32,6 @@ spec:
           value: "127.0.0.1"
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists


### PR DESCRIPTION
specifies system-cluster-critical priority for deployment.
updates image pull policy to IfNotPresent
blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217