### PR TITLE
[WIP] [DO NOT MERGE] Debug for BZ#1687295

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,6 +121,8 @@ func (c *Controller) handleNewCSR(key string) error {
 		if err != nil {
 			// Don't deny since it might be someone else's CSR
 			glog.Infof("CSR %s not authorized: %v", csr.GetName(), err)
+			glog.Infof("debug: %#v", machineList)
+			glog.Infof("debug: %#v", csr)
 			return nil
 		}
 	}
@@ -130,6 +132,8 @@ func (c *Controller) handleNewCSR(key string) error {
 		_, err := validateCSRContents(csr, parsedCSR)
 		if err != nil {
 			glog.Infof("CSR %s not valid: %v", csr.GetName(), err)
+			glog.Infof("debug: %#v", machineList)
+			glog.Infof("debug: %#v", csr)
 			return nil
 		}
 		approvalMsg += " (no SAN validation)"


### PR DESCRIPTION
We're looking for flake that reads 
```
openshift-tests [Area:Networking] multicast when using one of the plugins 'redhat/openshift-ovs-multitenant, redhat/openshift-ovs-networkpolicy' should allow multicast traffic in namespaces where it is enabled [Suite:openshift/conformance/parallel] 1m6s
go run hack/e2e.go -v -test --test_args='--ginkgo.focus=openshift\-tests\s\[Area\:Networking\]\smulticast\swhen\susing\sone\sof\sthe\splugins\s\'redhat\/openshift\-ovs\-multitenant\,\sredhat\/openshift\-ovs\-networkpolicy\'\sshould\sallow\smulticast\straffic\sin\snamespaces\swhere\sit\sis\senabled\s\[Suite\:openshift\/conformance\/parallel\]$'
fail [github.com/openshift/origin/test/extended/networking/multicast.go:50]: Expected success, but got an error:
    <*util.ExitError | 0xc422042900>: {
        Cmd: "oc exec --config=/tmp/configfile320269332 --namespace=e2e-test-multicast-wlzrp multicast-1 -- omping -c 5 -T 60 -q -q 10.129.2.33 10.129.2.35 10.128.2.52",
        StdErr: "Error from server: error dialing backend: remote error: tls: internal error",
        ExitError: {
```
/hold