### PR TITLE
Max CSR limit

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,8 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
-
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -20,32 +19,32 @@ type NodeClientCert struct {
 func loadConfig(cliConfig string) ClusterMachineApproverConfig {
 	config := ClusterMachineApproverConfig{}
 	defer func() {
-		glog.Infof("machine approver config: %+v", config)
+		klog.Infof("machine approver config: %+v", config)
 	}()
 
 	if len(cliConfig) == 0 {
-		glog.Info("using default as no cli config specified")
+		klog.Info("using default as no cli config specified")
 		return config
 	}
 
 	content, err := ioutil.ReadFile(cliConfig)
 	if err != nil {
-		glog.Infof("using default as failed to load config %s: %v", cliConfig, err)
+		klog.Infof("using default as failed to load config %s: %v", cliConfig, err)
 		return config
 	}
 	if len(content) == 0 {
-		glog.Infof("using default as config %s is empty", cliConfig)
+		klog.Infof("using default as config %s is empty", cliConfig)
 		return config
 	}
 
 	data, err := kyaml.ToJSON(content)
 	if err != nil {
-		glog.Infof("using default as failed to convert config %s to JSON: %v", cliConfig, err)
+		klog.Infof("using default as failed to convert config %s to JSON: %v", cliConfig, err)
 		return config
 	}
 
 	if err := json.Unmarshal(data, &config); err != nil {
-		glog.Infof("using default as failed to unmarshal config %s as JSON: %v", cliConfig, err)
+		klog.Infof("using default as failed to unmarshal config %s as JSON: %v", cliConfig, err)
 		return config
 	}
 

--- a/main.go
+++ b/main.go
@@ -209,6 +209,7 @@ func main() {
 		cliConfig  string
 	)
 
+	klog.InitFlags(nil)
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&master, "master", "", "master url")
 	flag.StringVar(&cliConfig, "config", "", "CLI config")


### PR DESCRIPTION
Currently the machine approver leave CSR pending if there's not legit machine for the node bootstrap CSR.
if pending CSR >100 the auto approver decides refuses to approve any CSR thereafter.
This can easily happen in a legit rapid scale up since each kubelet will create 2 CSRs
https://bugzilla.redhat.com/show_bug.cgi?id=1717610

This PR would deny CSRs for node bootstrapping with no legit backing machine and use denied CSRs as the threshold for blocking the approver