### PR TITLE
Increase the CSR retry count to 30

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,8 +159,8 @@ func (c *Controller) handleErr(err error, key interface{}) {
 		return
 	}
 
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.queue.NumRequeues(key) < 5 {
+	// This controller retries 30 times if something goes wrong. After that, it stops trying.
+	if c.queue.NumRequeues(key) < 30 {
 		klog.Infof("Error syncing csr %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the


### PR DESCRIPTION
The default exponential backoff is very low and sometimes a CSR will be
dropped from the queue betause the machine object did not have the
`nodeRef` added yet.

The current timeout is about 300 milliseconds. This should widen the
window. 10 retries result in about a 4 second window.

Fixes #40