### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: machine-approver
     machine-approver: "true"
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252