### PR TITLE
Fix IPv6 connections in getServingCert

### DIFF
--- a/csr_check.go
+++ b/csr_check.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -405,9 +406,9 @@ func getServingCert(nodes corev1client.NodeInterface, nodeName string, ca *x509.
 		return nil, err
 	}
 
-	port := node.Status.DaemonEndpoints.KubeletEndpoint.Port
+	port := strconv.Itoa(int(node.Status.DaemonEndpoints.KubeletEndpoint.Port))
 
-	kubelet := fmt.Sprintf("%s:%d", host, port)
+	kubelet := net.JoinHostPort(host, port)
 	dialer := &net.Dialer{Timeout: 30 * time.Second}
 	tlsConfig := &tls.Config{
 		RootCAs:    ca,

--- a/csr_check_test.go
+++ b/csr_check_test.go
@@ -2038,6 +2038,20 @@ func TestNodeInternalIP(t *testing.T) {
 			},
 			wantIP: "10.0.0.1",
 		},
+		{
+			name: "has ipv6 address",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "has-ipv6-address",
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "2600:1f18:4254:5100:ef8a:7b65:7782:9248"},
+					},
+				},
+			},
+			wantIP: "2600:1f18:4254:5100:ef8a:7b65:7782:9248",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Connections to IPv6 addresses were failing in `getServingCert` because
the address literal was not properly enclosed in square brackets.
This uses `net.JoinHostPort`, which handles this, in place of a simple
`fmt.Sprintf` call.