### PR TITLE
add exclusion annotations to all resources

### DIFF
--- a/manifests/00-ns.yaml
+++ b/manifests/00-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   name: openshift-cluster-machine-approver
   labels:
     openshift.io/run-level: "0"

--- a/manifests/0000_90_cluster-machine-approver_01_prometheusrole.yaml
+++ b/manifests/0000_90_cluster-machine-approver_01_prometheusrole.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_cluster-machine-approver_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_cluster-machine-approver_02_prometheusrolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-machine-approver_03_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-machine-approver_03_servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
     app: machine-approver
   name: cluster-machine-approver
   namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
+++ b/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
@@ -6,6 +6,8 @@ metadata:
     role: alert-rules
   name: machineapprover-rules
   namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: general.rules

--- a/manifests/01-rbac.yaml
+++ b/manifests/01-rbac.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   namespace: openshift-cluster-machine-approver
   name: machine-approver-sa
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11,6 +13,8 @@ kind: Role
 metadata:
   name: machine-approver
   namespace: openshift-config-managed
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -27,6 +31,8 @@ kind: RoleBinding
 metadata:
   name: machine-approver
   namespace: openshift-config-managed
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -41,6 +47,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:openshift:controller:machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - certificates.k8s.io
@@ -88,6 +96,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openshift:controller:machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/02-kube-rbac-proxy-config.yaml
+++ b/manifests/02-kube-rbac-proxy-config.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: kube-rbac-proxy
   namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   config-file.yaml: |+
     authorization:

--- a/manifests/03-metrics-service.yaml
+++ b/manifests/03-metrics-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cluster-machine-approver
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: machine-approver-tls
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: machine-approver
 spec:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.