### PR TITLE
Bug 1809329: ROKS - remove ClusterMachineApproverDown prometheus rule

### DIFF
--- a/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
+++ b/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
@@ -6,6 +6,8 @@ metadata:
     role: alert-rules
   name: machineapprover-rules
   namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: general.rules


### PR DESCRIPTION
Because the cluster machine approver is not deployed in a ROKS cluster, the alert that says that it's down should not be firing.