### PR TITLE
status: Add AsExpected reasons

### DIFF
--- a/status.go
+++ b/status.go
@@ -30,6 +30,7 @@ const (
 	unknownVersionValue           = "unknown"
 	queueKey                      = "trigger"
 	operatorVersionKey            = "operator"
+	reasonAsExpected              = "AsExpected"
 	releaseVersionEnvVariableName = "RELEASE_VERSION"
 )
 
@@ -186,28 +187,28 @@ func (c *statusController) statusAvailable() error {
 			Type:               osconfigv1.OperatorAvailable,
 			Status:             osconfigv1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
-			Reason:             "",
+			Reason:             reasonAsExpected,
 			Message:            fmt.Sprintf("Cluster Machine Approver is available at %s", c.versionGetter.GetVersions()["operator"]),
 		},
 		{
 			Type:               osconfigv1.OperatorDegraded,
 			Status:             osconfigv1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
-			Reason:             "",
+			Reason:             reasonAsExpected,
 			Message:            "",
 		},
 		{
 			Type:               osconfigv1.OperatorProgressing,
 			Status:             osconfigv1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
-			Reason:             "",
+			Reason:             reasonAsExpected,
 			Message:            "",
 		},
 		{
 			Type:               osconfigv1.OperatorUpgradeable,
 			Status:             osconfigv1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
-			Reason:             "",
+			Reason:             reasonAsExpected,
 			Message:            "",
 		},
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -110,9 +110,13 @@ var _ = Describe("Cluster Operator status controller", func() {
 
 			// check conditions.
 			Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, osconfigv1.OperatorAvailable)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(co.Status.Conditions, osconfigv1.OperatorAvailable).Reason).To(Equal(reasonAsExpected))
 			Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, osconfigv1.OperatorUpgradeable)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(co.Status.Conditions, osconfigv1.OperatorUpgradeable).Reason).To(Equal(reasonAsExpected))
 			Expect(v1helpers.IsStatusConditionFalse(co.Status.Conditions, osconfigv1.OperatorDegraded)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(co.Status.Conditions, osconfigv1.OperatorDegraded).Reason).To(Equal(reasonAsExpected))
 			Expect(v1helpers.IsStatusConditionFalse(co.Status.Conditions, osconfigv1.OperatorProgressing)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(co.Status.Conditions, osconfigv1.OperatorProgressing).Reason).To(Equal(reasonAsExpected))
 
 			// check related objects.
 			Expect(co.Status.RelatedObjects).To(Equal(relatedObjects))


### PR DESCRIPTION
We've used empty-string reasons since the status handling landed in ed1c8070d5 (#71).  But if we feel like we have a message we want to set to help humans understand the available condition, we should be setting a reason string for machines too.  `AsExpected` follows [the library-go precedent][1].

Also use `AsExpected` for some message-less but expected conditions, like `Progressing=False` and `Degraded=False`.  Having a reason makes it easier for folks skimming logs to see that the condition is in its happy state, and doesn't cost us any effort to set.

I am looking forward to the smarter logic promised by 91a58e6619 (#71), because the current blind assumption that everything is working seems... very optimistic ;).

[1]: https://github.com/openshift/library-go/blob/94c59dec54be25c8527e51e8c0a885712aeb01b5/pkg/operator/status/condition.go#L67