### PR TITLE
Bug 1866200: manifests: fix recording rules group name

### DIFF
--- a/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
+++ b/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
@@ -10,7 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
-    - name: general.rules
+    - name: cluster-machine-approver.rules
       rules:
         - alert: ClusterMachineApproverDown
           annotations:


### PR DESCRIPTION
The `general.rules` group name conflicts with others, causing them to be merged in OpenShift console via Thanos Querier.

This fixes it.