### PR TITLE
Bug 1872080: Create Dockerfile.rhel file

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,17 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-machine-approver
+COPY . .
+RUN make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder /go/src/github.com/openshift/cluster-machine-approver/machine-approver /usr/bin/
+COPY manifests /manifests
+ENTRYPOINT ["/usr/bin/machine-approver"]
+LABEL io.k8s.display-name="OpenShift cluster-machine-approver" \
+      io.k8s.description="This is an OpenShift component for approving new machines" \
+      com.redhat.component="cluster-machine-approver" \
+      maintainer="OpenShift Auth Team <aos-auth-team@redhat.com>" \
+      name="openshift/ose-cluster-machine-approver" \
+      version="v4.0.0" \
+      io.openshift.tags="openshift" \
+      io.openshift.release.operator=true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,17 +1,1 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
-WORKDIR /go/src/github.com/openshift/cluster-machine-approver
-COPY . .
-RUN make build
-
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
-COPY --from=builder /go/src/github.com/openshift/cluster-machine-approver/machine-approver /usr/bin/
-COPY manifests /manifests
-ENTRYPOINT ["/usr/bin/machine-approver"]
-LABEL io.k8s.display-name="OpenShift cluster-machine-approver" \
-      io.k8s.description="This is an OpenShift component for approving new machines" \
-      com.redhat.component="cluster-machine-approver" \
-      maintainer="OpenShift Auth Team <aos-auth-team@redhat.com>" \
-      name="openshift/ose-cluster-machine-approver" \
-      version="v4.0.0" \
-      io.openshift.tags="openshift" \
-      io.openshift.release.operator=true
+Dockerfile.rhel


### PR DESCRIPTION
This creates a Dockerfile.rhel file according to convention and symlink Dockerfile.rhel7 to the new one to satisfy tooling consumers until we switch them