### PR TITLE
Bug 1875036: Remove deprecated Dockerfile.rhel7 file

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,1 +1,0 @@
-Dockerfile.rhel


### PR DESCRIPTION
Since we consolidate on having Dockerfile.rhel named files in all repos and the build data is pointing to it https://github.com/openshift/ocp-build-data/pull/636 this can be dropped now