### PR TITLE
Bug 1879159: stop communicating with Kube API via localhost

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -68,10 +68,6 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
-        - name: KUBERNETES_SERVICE_PORT
-          value: "6443"
-        - name: KUBERNETES_SERVICE_HOST
-          value: "127.0.0.1"
         - name: METRICS_PORT
           value: "9191"
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Communicating with Kube API via localhost is discouraged because the caller doesn't know when the server is ready to serve the request. Reaching over the Kubernetes build-in service is preferred as it only contains the servers that are healthy and ready.

The following query shows that the operator frequently fails with errors like `127.0.0.1:6443: connect: connection refused` or `Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:openshift-cluster-machine-approver:machine-approver-sa" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope`

https://search.ci.openshift.org/?search=Failed+to+list+.*+is+forbidden%3A+.*+in+API+group&maxAge=48h&context=1&type=junit&name=&maxMatches=5&maxBytes=20971520&groupBy=job


from now on it should go via the kubernetes svc endpoint