### PR TITLE
Enable running make targets inside container

### DIFF
--- a/hack/go-mod.sh
+++ b/hack/go-mod.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+go mod tidy
+go mod vendor
+go mod verify

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
 
-REPO_NAME=$(basename "${PWD}")
-if [ "$IS_CONTAINER" != "" ]; then
-  for TARGET in "${@}"; do
-    find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+
-  done
-  git diff --exit-code
-else
-  docker run -it --rm \
-    --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
-    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
-    openshift/origin-release:golang-1.15 \
-    ./hack/goimports.sh "${@}"
-fi
+for TARGET in "${@}"; do
+  find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+
+done
+git diff --exit-code

--- a/hack/imagebuilder.sh
+++ b/hack/imagebuilder.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /tmp
+go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+cd -


### PR DESCRIPTION
Enable running make targets inside container with either `podman` or `docker`, podman being the default choice if installed, or outside container when `NO_DOCKER=1` specified.