### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/00-ns.yaml
+++ b/manifests/00-ns.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-cluster-machine-approver
   labels:
     openshift.io/run-level: "0"

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: machine-approver
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: machine-approver
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>