### PR TITLE
manifests/0000_90_cluster-machine-approver_04_alertrules: Drop ClusterMachineApproverDown

### DIFF
--- a/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
+++ b/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
@@ -14,15 +14,6 @@ spec:
   groups:
     - name: cluster-machine-approver.rules
       rules:
-        - alert: ClusterMachineApproverDown
-          annotations:
-            message: ClusterMachineApprover has disappeared from Prometheus target
-              discovery.
-          expr: |
-            absent(up{job="machine-approver"} == 1)
-          for: 10m
-          labels:
-            severity: critical
         - alert: MachineApproverMaxPendingCSRsReached
           expr: |
              mapi_current_pending_csr > mapi_max_pending_csr


### PR DESCRIPTION
The alert was added in 2e7f847b29 (#50).  But the cluster-version operator is responsible for complaining if the machine approver operator's deployment is sad, so no need for the operator to handle this directly (we end up doubling up if there's an issue).

Similar to openshift/cloud-credential-operator#308, openshift/cluster-autoscaler-operator#196, and openshift/machine-api-operator#826.