### PR TITLE
Add support for unstructured machines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/cluster-machine-approver
 go 1.16
 
 require (
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/openshift/api v0.0.0-20210816181336-8ff39b776da3

--- a/go.sum
+++ b/go.sum
@@ -518,6 +518,7 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=

--- a/main.go
+++ b/main.go
@@ -21,32 +21,44 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-machine-approver/pkg/controller"
 	"github.com/openshift/cluster-machine-approver/pkg/metrics"
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 	control "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
 
-	"k8s.io/klog/v2"
+const (
+	capiGroup = "cluster.x-k8s.io"
+	mapiGroup = "machine.openshift.io"
 )
 
 func main() {
 	var cliConfig string
 	var APIGroup string
+	var managementKubeConfigPath string
+	var workloadKubeConfigPath string
 
 	flagSet := flag.NewFlagSet("cluster-machine-approver", flag.ExitOnError)
 
 	klog.InitFlags(flagSet)
 	flagSet.StringVar(&cliConfig, "config", "", "CLI config")
+	flagSet.StringVar(&APIGroup, "apigroup", "machine.openshift.io", "API group for machines, defaults to machine.openshift.io")
+	flagSet.StringVar(&managementKubeConfigPath, "management-cluster-kubeconfig", "", "management kubeconfig path,")
+	flagSet.StringVar(&workloadKubeConfigPath, "workload-cluster-kubeconfig", "", "workload kubeconfig path")
+
 	flagSet.Parse(os.Args[1:])
 
-	flagSet.StringVar(&APIGroup, "apigroup", "machine.openshift.io", "API group for machines, defaults to machine.openshift.io")
+	if err := validateAPIGroup(APIGroup); err != nil {
+		klog.Fatalf(err.Error())
+	}
 
 	// Now let's start the controller
 	stop := make(chan struct{})
@@ -61,12 +73,20 @@ func main() {
 		metricsPort = fmt.Sprintf(":%d", v)
 	}
 
+	managementConfig, workloadConfig, err := createClientConfigs(managementKubeConfigPath, workloadKubeConfigPath)
+	if err != nil {
+		klog.Fatalf("Can't set client configs: %v", err)
+	}
+
+	managementClient, workloadClient, err := createClients(managementConfig, workloadConfig)
+	if err != nil {
+		klog.Fatalf("Can't create clients: %v", err)
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	klog.Info("setting up manager")
-	syncPeriod := 10 * time.Minute
-	mgr, err := manager.New(control.GetConfigOrDie(), manager.Options{
+	mgr, err := manager.New(managementConfig, manager.Options{
 		MetricsBindAddress: metricsPort,
-		SyncPeriod:         &syncPeriod,
 	})
 	if err != nil {
 		klog.Fatalf("unable to set up overall controller manager: %v", err)
@@ -79,27 +99,30 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	if err := machinev1.AddToScheme(mgr.GetScheme()); err != nil {
-		klog.Fatal("unable to add Machines to scheme")
-	}
-
-	directClient, err := client.New(mgr.GetConfig(), client.Options{
-		Scheme: mgr.GetScheme(),
-		Mapper: mgr.GetRESTMapper(),
-	})
-	if err != nil {
-		klog.Fatal("unable to set up client")
-	}
 	// Prevent the controller from caching node and machine objects.
 	// Stale nodes and machines can cause the approver to not approve certificates
 	// within a timely manner, leading to failed node bootstraps.
-	approverClient, err := client.NewDelegatingClient(client.NewDelegatingClientInput{
-		Client:      directClient,
+	uncachedManagementClient, err := client.NewDelegatingClient(client.NewDelegatingClientInput{
+		Client:      *managementClient,
 		CacheReader: mgr.GetClient(),
 		UncachedObjects: []client.Object{
-			&machinev1.Machine{},
 			&corev1.Node{},
 		},
+		// CacheUnstructured should be false because we manipulate with unstructured machines
+		CacheUnstructured: false,
+	})
+	if err != nil {
+		klog.Fatalf("unable to set up delegating client: %v", err)
+	}
+
+	uncachedWorkloadClient, err := client.NewDelegatingClient(client.NewDelegatingClientInput{
+		Client:      *workloadClient,
+		CacheReader: mgr.GetClient(),
+		UncachedObjects: []client.Object{
+			&corev1.Node{},
+		},
+		// CacheUnstructured should be false because we manipulate with unstructured machines
+		CacheUnstructured: false,
 	})
 	if err != nil {
 		klog.Fatalf("unable to set up delegating client: %v", err)
@@ -108,9 +131,12 @@ func main() {
 	// Setup all Controllers
 	klog.Info("setting up controllers")
 	if err = (&controller.CertificateApprover{
-		Client:  approverClient,
-		RestCfg: mgr.GetConfig(),
-		Config:  controller.LoadConfig(cliConfig),
+		MachineClient:  uncachedManagementClient,
+		MachineRestCfg: managementConfig,
+		NodeClient:     uncachedWorkloadClient,
+		NodeRestCfg:    workloadConfig,
+		Config:         controller.LoadConfig(cliConfig),
+		APIGroup:       APIGroup,
 	}).SetupWithManager(mgr, ctrl.Options{}); err != nil {
 		klog.Fatalf("unable to create CSR controller: %v", err)
 	}
@@ -124,4 +150,45 @@ func main() {
 	if err := mgr.Start(control.SetupSignalHandler()); err != nil {
 		klog.Fatalf("unable to run the manager: %v", err)
 	}
+}
+
+// createClientConfigs allow users to provide second config using management-kubeconfig, if specified
+// try to build it from provided path. First returned value is management config used for Machines,
+// second is workload config used for Node/CSRs.
+func createClientConfigs(managementKubeConfigPath, workloadKubeConfigPath string) (*rest.Config, *rest.Config, error) {
+	managementConfig, err := clientcmd.BuildConfigFromFlags("", managementKubeConfigPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	workloadConfig, err := clientcmd.BuildConfigFromFlags("", workloadKubeConfigPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return managementConfig, workloadConfig, nil
+}
+
+// createClients creates 2 API clients, First returned value is management client used for Machines,
+// second is workload client used for Node/CSRs.
+func createClients(managementConfig, workloadConfig *rest.Config) (*client.Client, *client.Client, error) {
+	managementClient, err := client.New(managementConfig, client.Options{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client: %v", err)
+	}
+
+	workloadClient, err := client.New(workloadConfig, client.Options{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client: %v", err)
+	}
+
+	return &managementClient, &workloadClient, nil
+}
+
+func validateAPIGroup(apiGroup string) error {
+	if apiGroup != capiGroup && apiGroup != mapiGroup {
+		return fmt.Errorf("unsupported APIGroup %s, allowed values %s, %s", apiGroup, capiGroup, mapiGroup)
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -38,12 +38,15 @@ import (
 
 func main() {
 	var cliConfig string
+	var APIGroup string
 
 	flagSet := flag.NewFlagSet("cluster-machine-approver", flag.ExitOnError)
 
 	klog.InitFlags(flagSet)
 	flagSet.StringVar(&cliConfig, "config", "", "CLI config")
 	flagSet.Parse(os.Args[1:])
+
+	flagSet.StringVar(&APIGroup, "apigroup", "machine.openshift.io", "API group for machines, defaults to machine.openshift.io")
 
 	// Now let's start the controller
 	stop := make(chan struct{})

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	klog.Info("setting up manager")
-	mgr, err := manager.New(managementConfig, manager.Options{
+	mgr, err := manager.New(workloadConfig, manager.Options{
 		MetricsBindAddress: metricsPort,
 	})
 	if err != nil {
@@ -105,9 +105,6 @@ func main() {
 	uncachedManagementClient, err := client.NewDelegatingClient(client.NewDelegatingClientInput{
 		Client:      *managementClient,
 		CacheReader: mgr.GetClient(),
-		UncachedObjects: []client.Object{
-			&corev1.Node{},
-		},
 		// CacheUnstructured should be false because we manipulate with unstructured machines
 		CacheUnstructured: false,
 	})
@@ -121,8 +118,6 @@ func main() {
 		UncachedObjects: []client.Object{
 			&corev1.Node{},
 		},
-		// CacheUnstructured should be false because we manipulate with unstructured machines
-		CacheUnstructured: false,
 	})
 	if err != nil {
 		klog.Fatalf("unable to set up delegating client: %v", err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,16 +7,14 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinehandlerpkg "github.com/openshift/cluster-machine-approver/pkg/machinehandler"
 	certificatesv1 "k8s.io/api/certificates/v1"
-	certificatesv1client "k8s.io/client-go/kubernetes/typed/certificates/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	certificatesv1client "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,8 +34,9 @@ const (
 // MachineApproverReconciler reconciles a machine-approver  object
 type CertificateApprover struct {
 	client.Client
-	RestCfg *rest.Config
-	Config  ClusterMachineApproverConfig
+	RestCfg  *rest.Config
+	Config   ClusterMachineApproverConfig
+	APIGroup string
 }
 
 func (m *CertificateApprover) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
@@ -117,8 +116,15 @@ func (m *CertificateApprover) Reconcile(ctx context.Context, req ctrl.Request) (
 		return reconcile.Result{}, fmt.Errorf("Failed to get CSRs: %w", err)
 	}
 
-	machines := &machinev1.MachineList{}
-	if err := m.List(ctx, machines); err != nil {
+	machineHandler := &machinehandlerpkg.MachineHandler{
+		Client:   m.Client,
+		Config:   m.RestCfg,
+		Ctx:      ctx,
+		APIGroup: m.APIGroup,
+	}
+
+	machines, err := machineHandler.ListMachines()
+	if err != nil {
 		klog.Errorf("%v: Failed to list machines: %v", req.Name, err)
 		return reconcile.Result{}, fmt.Errorf("Failed to list machines: %w", err)
 	}
@@ -140,8 +146,8 @@ func (m *CertificateApprover) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // reconcileLimits will short circut logic if number of pending CSRs is exceeding limit
-func reconcileLimits(csrName string, machines *machinev1.MachineList, csrs *certificatesv1.CertificateSigningRequestList) bool {
-	maxPending := getMaxPending(machines.Items)
+func reconcileLimits(csrName string, machines []machinehandlerpkg.Machine, csrs *certificatesv1.CertificateSigningRequestList) bool {
+	maxPending := getMaxPending(machines)
 	atomic.StoreUint32(&MaxPendingCSRs, uint32(maxPending))
 	pending := recentlyPendingCSRs(csrs.Items)
 	atomic.StoreUint32(&PendingCSRs, uint32(pending))
@@ -153,7 +159,7 @@ func reconcileLimits(csrName string, machines *machinev1.MachineList, csrs *cert
 	return false
 }
 
-func (m *CertificateApprover) reconcileCSR(csr certificatesv1.CertificateSigningRequest, machines *machinev1.MachineList) error {
+func (m *CertificateApprover) reconcileCSR(csr certificatesv1.CertificateSigningRequest, machines []machinehandlerpkg.Machine) error {
 	parsedCSR, err := parseCSR(&csr)
 	if err != nil {
 		klog.Errorf("%v: Failed to parse csr: %v", csr.Name, err)
@@ -167,7 +173,7 @@ func (m *CertificateApprover) reconcileCSR(csr certificatesv1.CertificateSigning
 		klog.Errorf("failed to get kubelet CA")
 	}
 
-	if authorize, err := authorizeCSR(m, m.Config, machines.Items, &csr, parsedCSR, kubeletCA); !authorize {
+	if authorize, err := authorizeCSR(m.NodeClient, m.Config, machines, &csr, parsedCSR, kubeletCA); !authorize {
 		// Don't deny since it might be someone else's CSR
 		klog.Infof("%s: CSR not authorized", csr.Name)
 		return err
@@ -239,6 +245,6 @@ func parseCSR(obj *certificatesv1.CertificateSigningRequest) (*x509.CertificateR
 	return x509.ParseCertificateRequest(block.Bytes)
 }
 
-func getMaxPending(machines []machinev1.Machine) int {
+func getMaxPending(machines []machinehandlerpkg.Machine) int {
 	return len(machines) + maxDiffBetweenPendingCSRsAndMachinesCount
 }

--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinehandlerpkg "github.com/openshift/cluster-machine-approver/pkg/machinehandler"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -129,7 +129,7 @@ func validateCSRContents(req *certificatesv1.CertificateSigningRequest, csr *x50
 func authorizeCSR(
 	c client.Client,
 	config ClusterMachineApproverConfig,
-	machines []machinev1.Machine,
+	machines []machinehandlerpkg.Machine,
 	req *certificatesv1.CertificateSigningRequest,
 	csr *x509.CertificateRequest,
 	ca *x509.CertPool,
@@ -191,8 +191,8 @@ func authorizeCSR(
 	klog.Infof("Falling back to machine-api authorization for %s", nodeAsking)
 
 	// Check that we have a registered node with the request name
-	targetMachine, ok := findMatchingMachineFromNodeRef(nodeAsking, machines)
-	if !ok {
+	targetMachine, err := machinehandlerpkg.FindMatchingMachineFromNodeRef(machines, nodeAsking)
+	if err != nil {
 		klog.Errorf("%v: Serving Cert: No target machine for node %q", req.Name, nodeAsking)
 		//TODO: set annotation/emit event here.
 		// Return error so we requeue in case we're racing with node linker.
@@ -209,7 +209,7 @@ func authorizeCSR(
 		var attemptedAddresses []string
 		var foundSan bool
 		for _, addr := range targetMachine.Status.Addresses {
-			switch addr.Type {
+			switch corev1.NodeAddressType(addr.Type) {
 			case corev1.NodeInternalDNS, corev1.NodeExternalDNS, corev1.NodeHostName:
 				if san == addr.Address {
 					foundSan = true
@@ -237,7 +237,7 @@ func authorizeCSR(
 		var attemptedAddresses []string
 		var foundSan bool
 		for _, addr := range targetMachine.Status.Addresses {
-			switch addr.Type {
+			switch corev1.NodeAddressType(addr.Type) {
 			case corev1.NodeInternalIP, corev1.NodeExternalIP:
 				if san.String() == addr.Address {
 					foundSan = true
@@ -261,8 +261,7 @@ func authorizeCSR(
 	return true, nil
 }
 
-func authorizeNodeClientCSR(c client.Client, machines []machinev1.Machine, req *certificatesv1.CertificateSigningRequest, csr *x509.CertificateRequest) (bool, error) {
-
+func authorizeNodeClientCSR(c client.Client, machines []machinehandlerpkg.Machine, req *certificatesv1.CertificateSigningRequest, csr *x509.CertificateRequest) (bool, error) {
 	if !isReqFromNodeBootstrapper(req) {
 		klog.Infof("%v: CSR does not appear to be a valid node bootstrapper client cert request", req.Name)
 		return false, nil
@@ -285,8 +284,8 @@ func authorizeNodeClientCSR(c client.Client, machines []machinev1.Machine, req *
 		return false, nil
 	}
 
-	nodeMachine, ok := findMatchingMachineFromInternalDNS(nodeName, machines)
-	if !ok {
+	nodeMachine, err := machinehandlerpkg.FindMatchingMachineFromInternalDNS(machines, nodeName)
+	if err != nil {
 		//TODO: set annotation/emit event here.
 		klog.Errorf("%v: failed to find machine for node %s, cannot approve", req.Name, nodeName)
 		return false, fmt.Errorf("failed to find machine for node %s", nodeName)
@@ -294,12 +293,12 @@ func authorizeNodeClientCSR(c client.Client, machines []machinev1.Machine, req *
 
 	if nodeMachine.Status.NodeRef != nil {
 		//TODO: set annotation/emit event here.
-		klog.Errorf("%v: machine for node %s already has node ref, cannot approve", req.Name, nodeName)
+		klog.Errorf("%v: machine for node %v already has node ref, cannot approve", nodeMachine.Status.NodeRef)
 		return false, nil
 	}
 
-	start := nodeMachine.CreationTimestamp.Add(-maxMachineClockSkew)
-	end := nodeMachine.CreationTimestamp.Add(maxMachineDelta)
+	start := nodeMachine.ObjectMeta.CreationTimestamp.Add(-maxMachineClockSkew)
+	end := nodeMachine.ObjectMeta.CreationTimestamp.Add(maxMachineDelta)
 	if !inTimeSpan(start, end, req.CreationTimestamp.Time) {
 		//TODO: set annotation/emit event here.
 		klog.Errorf("%v: CSR creation time %s not in range (%s, %s)", req.Name, req.CreationTimestamp.Time, start, end)
@@ -352,26 +351,6 @@ func authorizeServingRenewal(nodeName string, csr *x509.CertificateRequest, curr
 
 func isReqFromNodeBootstrapper(req *certificatesv1.CertificateSigningRequest) bool {
 	return req.Spec.Username == nodeBootstrapperUsername && nodeBootstrapperGroups.Equal(sets.NewString(req.Spec.Groups...))
-}
-
-func findMatchingMachineFromNodeRef(nodeName string, machines []machinev1.Machine) (machinev1.Machine, bool) {
-	for _, machine := range machines {
-		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == nodeName {
-			return machine, true
-		}
-	}
-	return machinev1.Machine{}, false
-}
-
-func findMatchingMachineFromInternalDNS(nodeName string, machines []machinev1.Machine) (machinev1.Machine, bool) {
-	for _, machine := range machines {
-		for _, address := range machine.Status.Addresses {
-			if address.Type == corev1.NodeInternalDNS && address.Address == nodeName {
-				return machine, true
-			}
-		}
-	}
-	return machinev1.Machine{}, false
 }
 
 func inTimeSpan(start, end, check time.Time) bool {

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinehandlerpkg "github.com/openshift/cluster-machine-approver/pkg/machinehandler"
 )
 
 /*
@@ -451,7 +451,7 @@ func Test_authorizeCSR(t *testing.T) {
 
 	type args struct {
 		config        ClusterMachineApproverConfig
-		machines      []machinev1.Machine
+		machines      []machinehandlerpkg.Machine
 		node          *corev1.Node
 		kubeletServer net.Listener
 		req           *certificatesv1.CertificateSigningRequest
@@ -467,9 +467,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "ok",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -525,9 +525,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "no-node-prefix",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -574,9 +574,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "only-node-prefix",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -623,9 +623,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "no-machine-status-ref",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{},
+						Status: machinehandlerpkg.MachineStatus{},
 					},
 				},
 				req: &certificatesv1.CertificateSigningRequest{
@@ -650,9 +650,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "missing-groups-1",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -698,9 +698,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "missing-groups-2",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -746,9 +746,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "extra-group",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -796,9 +796,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "wrong-group",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -845,9 +845,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usages-missing",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -892,9 +892,9 @@ func Test_authorizeCSR(t *testing.T) {
 		}, {
 			name: "usages-missing",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -941,9 +941,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usages-missing-1",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -989,9 +989,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usage-missing-2",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1037,9 +1037,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usage-extra",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1087,9 +1087,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-cn",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1136,9 +1136,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-cn-2",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1185,9 +1185,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-no-o",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1234,9 +1234,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-extra-addr",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1283,9 +1283,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-san-ip-mismatch",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1332,9 +1332,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-san-dns-mismatch",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -1382,9 +1382,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1394,7 +1394,7 @@ func Test_authorizeCSR(t *testing.T) {
 						},
 					},
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1427,9 +1427,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client extra O",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1463,9 +1463,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client with DNS",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1499,9 +1499,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but extra usage",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1536,9 +1536,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but wrong usage",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1572,9 +1572,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but missing usage",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1607,9 +1607,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but wrong CN",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1643,9 +1643,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but wrong user",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1680,9 +1680,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but wrong user group",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1718,9 +1718,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but empty name",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1755,9 +1755,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but node exists",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1791,9 +1791,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but missing machine",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeExternalDNS,
@@ -1826,9 +1826,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but machine has node ref",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{Name: "other"},
 							Addresses: []corev1.NodeAddress{
 								{
@@ -1867,9 +1867,9 @@ func Test_authorizeCSR(t *testing.T) {
 						Disabled: true,
 					},
 				},
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1879,7 +1879,7 @@ func Test_authorizeCSR(t *testing.T) {
 						},
 					},
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1914,9 +1914,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good with proper timing",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1929,7 +1929,7 @@ func Test_authorizeCSR(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(2 * time.Minute),
 						},
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1966,9 +1966,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good with proper timing 2",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -1981,7 +1981,7 @@ func Test_authorizeCSR(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(3 * time.Minute),
 						},
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -2018,9 +2018,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but CSR too early",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -2033,7 +2033,7 @@ func Test_authorizeCSR(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(3 * time.Minute),
 						},
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -2070,9 +2070,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "client good but CSR too late",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -2085,7 +2085,7 @@ func Test_authorizeCSR(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(3 * time.Minute),
 						},
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							Addresses: []corev1.NodeAddress{
 								{
 									Type:    corev1.NodeInternalDNS,
@@ -2149,9 +2149,9 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "successfull fallback to fresh approval",
 			args: args{
-				machines: []machinev1.Machine{
+				machines: []machinehandlerpkg.Machine{
 					{
-						Status: machinev1.MachineStatus{
+						Status: machinehandlerpkg.MachineStatus{
 							NodeRef: &corev1.ObjectReference{
 								Name: "test",
 							},
@@ -2636,12 +2636,12 @@ func creationTimestamp(delta time.Duration) metav1.Time {
 }
 
 func TestGetMaxPending(t *testing.T) {
-	ml := []machinev1.Machine{
+	ml := []machinehandlerpkg.Machine{
 		{
-			Status: machinev1.MachineStatus{},
+			Status: machinehandlerpkg.MachineStatus{},
 		},
 		{
-			Status: machinev1.MachineStatus{},
+			Status: machinehandlerpkg.MachineStatus{},
 		},
 	}
 

--- a/pkg/machinehandler/machinehandler.go
+++ b/pkg/machinehandler/machinehandler.go
@@ -1,0 +1,132 @@
+package machinehandler
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrUnstructuredFieldNotFound = fmt.Errorf("field not found")
+)
+
+type MachineHandler struct {
+	APIGroup string
+	Client   client.Client
+	Config   *rest.Config
+	Ctx      context.Context
+}
+
+type Machine struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Status            MachineStatus `json:"status,omitempty"`
+}
+type MachineStatus struct {
+	NodeRef   *corev1.ObjectReference `json:"nodeRef,omitempty"`
+	Addresses []corev1.NodeAddress    `json:"addresses,omitempty"`
+}
+
+// ListMachines list all machines using given client
+func (m *MachineHandler) ListMachines() ([]Machine, error) {
+	APIVersion, err := m.getAPIGroupPreferredVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredMachineList := &unstructured.UnstructuredList{}
+	unstructuredMachineList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   m.APIGroup,
+		Kind:    "MachineList",
+		Version: APIVersion,
+	})
+	if err := m.Client.List(m.Ctx, unstructuredMachineList); err != nil {
+		return nil, err
+	}
+
+	machines := []Machine{}
+
+	stringToTimeHook := func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() == reflect.String && t == reflect.TypeOf(metav1.Time{}) {
+			time, err := time.Parse(time.RFC3339, data.(string))
+			return metav1.Time{Time: time}, err
+		}
+		return data, nil
+	}
+
+	for _, obj := range unstructuredMachineList.Items {
+		machine := Machine{}
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			TagName:    "json",
+			Result:     &machine,
+			DecodeHook: stringToTimeHook,
+		})
+		if err != nil {
+			return nil, err
+		}
+		err = decoder.Decode(obj.Object)
+		if err != nil {
+			return nil, err
+		}
+		machines = append(machines, machine)
+	}
+
+	return machines, nil
+}
+
+// getAPIGroupPreferredVersion get preferred API version using API group
+func (m *MachineHandler) getAPIGroupPreferredVersion() (string, error) {
+	if m.Config == nil {
+		return "", fmt.Errorf("machine handler config can't be nil")
+	}
+
+	managementDiscoveryClient, err := discovery.NewDiscoveryClientForConfig(m.Config)
+	if err != nil {
+		return "", fmt.Errorf("create discovery client failed: %v", err)
+	}
+
+	groupList, err := managementDiscoveryClient.ServerGroups()
+	if err != nil {
+		return "", fmt.Errorf("failed to get ServerGroups: %v", err)
+	}
+
+	for _, group := range groupList.Groups {
+		if group.Name == m.APIGroup {
+			return group.PreferredVersion.Version, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find API group %q", m.APIGroup)
+}
+
+// FindMatchingMachineFromInternalDNS find matching machine for node using internal DNS
+func FindMatchingMachineFromInternalDNS(machines []Machine, nodeName string) (*Machine, error) {
+	for _, machine := range machines {
+		for _, address := range machine.Status.Addresses {
+			if corev1.NodeAddressType(address.Type) == corev1.NodeInternalDNS && address.Address == nodeName {
+				return &machine, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("matching machine not found")
+}
+
+// FindMatchingMachineFromNodeRef find matching machine for node using node ref
+func FindMatchingMachineFromNodeRef(machines []Machine, nodeName string) (*Machine, error) {
+	for _, machine := range machines {
+		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == nodeName {
+			return &machine, nil
+		}
+
+	}
+	return nil, fmt.Errorf("matching machine not found")
+}

--- a/vendor/github.com/mitchellh/mapstructure/.travis.yml
+++ b/vendor/github.com/mitchellh/mapstructure/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - "1.11.x"
+  - tip
+
+script:
+  - go test

--- a/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
+++ b/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
@@ -1,0 +1,21 @@
+## 1.1.2
+
+* Fix error when decode hook decodes interface implementation into interface
+  type. [GH-140]
+
+## 1.1.1
+
+* Fix panic that can happen in `decodePtr`
+
+## 1.1.0
+
+* Added `StringToIPHookFunc` to convert `string` to `net.IP` and `net.IPNet` [GH-133]
+* Support struct to struct decoding [GH-137]
+* If source map value is nil, then destination map value is nil (instead of empty)
+* If source slice value is nil, then destination slice value is nil (instead of empty)
+* If source pointer is nil, then destination pointer is set to nil (instead of
+  allocated zero value of type)
+
+## 1.0.0
+
+* Initial tagged stable release.

--- a/vendor/github.com/mitchellh/mapstructure/LICENSE
+++ b/vendor/github.com/mitchellh/mapstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/mapstructure/README.md
+++ b/vendor/github.com/mitchellh/mapstructure/README.md
@@ -1,0 +1,46 @@
+# mapstructure [![Godoc](https://godoc.org/github.com/mitchellh/mapstructure?status.svg)](https://godoc.org/github.com/mitchellh/mapstructure)
+
+mapstructure is a Go library for decoding generic map values to structures
+and vice versa, while providing helpful error handling.
+
+This library is most useful when decoding values from some data stream (JSON,
+Gob, etc.) where you don't _quite_ know the structure of the underlying data
+until you read a part of it. You can therefore read a `map[string]interface{}`
+and use this library to decode it into the proper underlying native Go
+structure.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/mapstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/mapstructure).
+
+The `Decode` function has examples associated with it there.
+
+## But Why?!
+
+Go offers fantastic standard libraries for decoding formats such as JSON.
+The standard method is to have a struct pre-created, and populate that struct
+from the bytes of the encoded format. This is great, but the problem is if
+you have configuration or an encoding that changes slightly depending on
+specific fields. For example, consider this JSON:
+
+```json
+{
+  "type": "person",
+  "name": "Mitchell"
+}
+```
+
+Perhaps we can't populate a specific structure without first reading
+the "type" field from the JSON. We could always do two passes over the
+decoding of the JSON (reading the "type" first, and the rest later).
+However, it is much simpler to just decode this into a `map[string]interface{}`
+structure, read the "type" key, then use something like this library
+to decode it into the proper structure.

--- a/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
+++ b/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
@@ -1,0 +1,217 @@
+package mapstructure
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// typedDecodeHook takes a raw DecodeHookFunc (an interface{}) and turns
+// it into the proper DecodeHookFunc type, such as DecodeHookFuncType.
+func typedDecodeHook(h DecodeHookFunc) DecodeHookFunc {
+	// Create variables here so we can reference them with the reflect pkg
+	var f1 DecodeHookFuncType
+	var f2 DecodeHookFuncKind
+
+	// Fill in the variables into this interface and the rest is done
+	// automatically using the reflect package.
+	potential := []interface{}{f1, f2}
+
+	v := reflect.ValueOf(h)
+	vt := v.Type()
+	for _, raw := range potential {
+		pt := reflect.ValueOf(raw).Type()
+		if vt.ConvertibleTo(pt) {
+			return v.Convert(pt).Interface()
+		}
+	}
+
+	return nil
+}
+
+// DecodeHookExec executes the given decode hook. This should be used
+// since it'll naturally degrade to the older backwards compatible DecodeHookFunc
+// that took reflect.Kind instead of reflect.Type.
+func DecodeHookExec(
+	raw DecodeHookFunc,
+	from reflect.Type, to reflect.Type,
+	data interface{}) (interface{}, error) {
+	switch f := typedDecodeHook(raw).(type) {
+	case DecodeHookFuncType:
+		return f(from, to, data)
+	case DecodeHookFuncKind:
+		return f(from.Kind(), to.Kind(), data)
+	default:
+		return nil, errors.New("invalid decode hook signature")
+	}
+}
+
+// ComposeDecodeHookFunc creates a single DecodeHookFunc that
+// automatically composes multiple DecodeHookFuncs.
+//
+// The composed funcs are called in order, with the result of the
+// previous transformation.
+func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		var err error
+		for _, f1 := range fs {
+			data, err = DecodeHookExec(f1, f, t, data)
+			if err != nil {
+				return nil, err
+			}
+
+			// Modify the from kind to be correct with the new data
+			f = nil
+			if val := reflect.ValueOf(data); val.IsValid() {
+				f = val.Type()
+			}
+		}
+
+		return data, nil
+	}
+}
+
+// StringToSliceHookFunc returns a DecodeHookFunc that converts
+// string to []string by splitting on the given sep.
+func StringToSliceHookFunc(sep string) DecodeHookFunc {
+	return func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{}) (interface{}, error) {
+		if f != reflect.String || t != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return []string{}, nil
+		}
+
+		return strings.Split(raw, sep), nil
+	}
+}
+
+// StringToTimeDurationHookFunc returns a DecodeHookFunc that converts
+// strings to time.Duration.
+func StringToTimeDurationHookFunc() DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(time.Duration(5)) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		return time.ParseDuration(data.(string))
+	}
+}
+
+// StringToIPHookFunc returns a DecodeHookFunc that converts
+// strings to net.IP
+func StringToIPHookFunc() DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(net.IP{}) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		ip := net.ParseIP(data.(string))
+		if ip == nil {
+			return net.IP{}, fmt.Errorf("failed parsing ip %v", data)
+		}
+
+		return ip, nil
+	}
+}
+
+// StringToIPNetHookFunc returns a DecodeHookFunc that converts
+// strings to net.IPNet
+func StringToIPNetHookFunc() DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(net.IPNet{}) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		_, net, err := net.ParseCIDR(data.(string))
+		return net, err
+	}
+}
+
+// StringToTimeHookFunc returns a DecodeHookFunc that converts
+// strings to time.Time.
+func StringToTimeHookFunc(layout string) DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(time.Time{}) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		return time.Parse(layout, data.(string))
+	}
+}
+
+// WeaklyTypedHook is a DecodeHookFunc which adds support for weak typing to
+// the decoder.
+//
+// Note that this is significantly different from the WeaklyTypedInput option
+// of the DecoderConfig.
+func WeaklyTypedHook(
+	f reflect.Kind,
+	t reflect.Kind,
+	data interface{}) (interface{}, error) {
+	dataVal := reflect.ValueOf(data)
+	switch t {
+	case reflect.String:
+		switch f {
+		case reflect.Bool:
+			if dataVal.Bool() {
+				return "1", nil
+			}
+			return "0", nil
+		case reflect.Float32:
+			return strconv.FormatFloat(dataVal.Float(), 'f', -1, 64), nil
+		case reflect.Int:
+			return strconv.FormatInt(dataVal.Int(), 10), nil
+		case reflect.Slice:
+			dataType := dataVal.Type()
+			elemKind := dataType.Elem().Kind()
+			if elemKind == reflect.Uint8 {
+				return string(dataVal.Interface().([]uint8)), nil
+			}
+		case reflect.Uint:
+			return strconv.FormatUint(dataVal.Uint(), 10), nil
+		}
+	}
+
+	return data, nil
+}

--- a/vendor/github.com/mitchellh/mapstructure/error.go
+++ b/vendor/github.com/mitchellh/mapstructure/error.go
@@ -1,0 +1,50 @@
+package mapstructure
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Error implements the error interface and can represents multiple
+// errors that occur in the course of a single decode.
+type Error struct {
+	Errors []string
+}
+
+func (e *Error) Error() string {
+	points := make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	sort.Strings(points)
+	return fmt.Sprintf(
+		"%d error(s) decoding:\n\n%s",
+		len(e.Errors), strings.Join(points, "\n"))
+}
+
+// WrappedErrors implements the errwrap.Wrapper interface to make this
+// return value more useful with the errwrap and go-multierror libraries.
+func (e *Error) WrappedErrors() []error {
+	if e == nil {
+		return nil
+	}
+
+	result := make([]error, len(e.Errors))
+	for i, e := range e.Errors {
+		result[i] = errors.New(e)
+	}
+
+	return result
+}
+
+func appendErrors(errors []string, err error) []string {
+	switch e := err.(type) {
+	case *Error:
+		return append(errors, e.Errors...)
+	default:
+		return append(errors, e.Error())
+	}
+}

--- a/vendor/github.com/mitchellh/mapstructure/go.mod
+++ b/vendor/github.com/mitchellh/mapstructure/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/mapstructure

--- a/vendor/github.com/mitchellh/mapstructure/mapstructure.go
+++ b/vendor/github.com/mitchellh/mapstructure/mapstructure.go
@@ -1,0 +1,1149 @@
+// Package mapstructure exposes functionality to convert an arbitrary
+// map[string]interface{} into a native Go structure.
+//
+// The Go structure can be arbitrarily complex, containing slices,
+// other structs, etc. and the decoder will properly decode nested
+// maps and so on into the proper structures in the native Go struct.
+// See the examples to see what the decoder is capable of.
+package mapstructure
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// DecodeHookFunc is the callback function that can be used for
+// data transformations. See "DecodeHook" in the DecoderConfig
+// struct.
+//
+// The type should be DecodeHookFuncType or DecodeHookFuncKind.
+// Either is accepted. Types are a superset of Kinds (Types can return
+// Kinds) and are generally a richer thing to use, but Kinds are simpler
+// if you only need those.
+//
+// The reason DecodeHookFunc is multi-typed is for backwards compatibility:
+// we started with Kinds and then realized Types were the better solution,
+// but have a promise to not break backwards compat so we now support
+// both.
+type DecodeHookFunc interface{}
+
+// DecodeHookFuncType is a DecodeHookFunc which has complete information about
+// the source and target types.
+type DecodeHookFuncType func(reflect.Type, reflect.Type, interface{}) (interface{}, error)
+
+// DecodeHookFuncKind is a DecodeHookFunc which knows only the Kinds of the
+// source and target types.
+type DecodeHookFuncKind func(reflect.Kind, reflect.Kind, interface{}) (interface{}, error)
+
+// DecoderConfig is the configuration that is used to create a new decoder
+// and allows customization of various aspects of decoding.
+type DecoderConfig struct {
+	// DecodeHook, if set, will be called before any decoding and any
+	// type conversion (if WeaklyTypedInput is on). This lets you modify
+	// the values before they're set down onto the resulting struct.
+	//
+	// If an error is returned, the entire decode will fail with that
+	// error.
+	DecodeHook DecodeHookFunc
+
+	// If ErrorUnused is true, then it is an error for there to exist
+	// keys in the original map that were unused in the decoding process
+	// (extra keys).
+	ErrorUnused bool
+
+	// ZeroFields, if set to true, will zero fields before writing them.
+	// For example, a map will be emptied before decoded values are put in
+	// it. If this is false, a map will be merged.
+	ZeroFields bool
+
+	// If WeaklyTypedInput is true, the decoder will make the following
+	// "weak" conversions:
+	//
+	//   - bools to string (true = "1", false = "0")
+	//   - numbers to string (base 10)
+	//   - bools to int/uint (true = 1, false = 0)
+	//   - strings to int/uint (base implied by prefix)
+	//   - int to bool (true if value != 0)
+	//   - string to bool (accepts: 1, t, T, TRUE, true, True, 0, f, F,
+	//     FALSE, false, False. Anything else is an error)
+	//   - empty array = empty map and vice versa
+	//   - negative numbers to overflowed uint values (base 10)
+	//   - slice of maps to a merged map
+	//   - single values are converted to slices if required. Each
+	//     element is weakly decoded. For example: "4" can become []int{4}
+	//     if the target type is an int slice.
+	//
+	WeaklyTypedInput bool
+
+	// Metadata is the struct that will contain extra metadata about
+	// the decoding. If this is nil, then no metadata will be tracked.
+	Metadata *Metadata
+
+	// Result is a pointer to the struct that will contain the decoded
+	// value.
+	Result interface{}
+
+	// The tag name that mapstructure reads for field names. This
+	// defaults to "mapstructure"
+	TagName string
+}
+
+// A Decoder takes a raw interface value and turns it into structured
+// data, keeping track of rich error information along the way in case
+// anything goes wrong. Unlike the basic top-level Decode method, you can
+// more finely control how the Decoder behaves using the DecoderConfig
+// structure. The top-level Decode method is just a convenience that sets
+// up the most basic Decoder.
+type Decoder struct {
+	config *DecoderConfig
+}
+
+// Metadata contains information about decoding a structure that
+// is tedious or difficult to get otherwise.
+type Metadata struct {
+	// Keys are the keys of the structure which were successfully decoded
+	Keys []string
+
+	// Unused is a slice of keys that were found in the raw value but
+	// weren't decoded since there was no matching field in the result interface
+	Unused []string
+}
+
+// Decode takes an input structure and uses reflection to translate it to
+// the output structure. output must be a pointer to a map or struct.
+func Decode(input interface{}, output interface{}) error {
+	config := &DecoderConfig{
+		Metadata: nil,
+		Result:   output,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+// WeakDecode is the same as Decode but is shorthand to enable
+// WeaklyTypedInput. See DecoderConfig for more info.
+func WeakDecode(input, output interface{}) error {
+	config := &DecoderConfig{
+		Metadata:         nil,
+		Result:           output,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+// DecodeMetadata is the same as Decode, but is shorthand to
+// enable metadata collection. See DecoderConfig for more info.
+func DecodeMetadata(input interface{}, output interface{}, metadata *Metadata) error {
+	config := &DecoderConfig{
+		Metadata: metadata,
+		Result:   output,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+// WeakDecodeMetadata is the same as Decode, but is shorthand to
+// enable both WeaklyTypedInput and metadata collection. See
+// DecoderConfig for more info.
+func WeakDecodeMetadata(input interface{}, output interface{}, metadata *Metadata) error {
+	config := &DecoderConfig{
+		Metadata:         metadata,
+		Result:           output,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+// NewDecoder returns a new decoder for the given configuration. Once
+// a decoder has been returned, the same configuration must not be used
+// again.
+func NewDecoder(config *DecoderConfig) (*Decoder, error) {
+	val := reflect.ValueOf(config.Result)
+	if val.Kind() != reflect.Ptr {
+		return nil, errors.New("result must be a pointer")
+	}
+
+	val = val.Elem()
+	if !val.CanAddr() {
+		return nil, errors.New("result must be addressable (a pointer)")
+	}
+
+	if config.Metadata != nil {
+		if config.Metadata.Keys == nil {
+			config.Metadata.Keys = make([]string, 0)
+		}
+
+		if config.Metadata.Unused == nil {
+			config.Metadata.Unused = make([]string, 0)
+		}
+	}
+
+	if config.TagName == "" {
+		config.TagName = "mapstructure"
+	}
+
+	result := &Decoder{
+		config: config,
+	}
+
+	return result, nil
+}
+
+// Decode decodes the given raw interface to the target pointer specified
+// by the configuration.
+func (d *Decoder) Decode(input interface{}) error {
+	return d.decode("", input, reflect.ValueOf(d.config.Result).Elem())
+}
+
+// Decodes an unknown data type into a specific reflection value.
+func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) error {
+	var inputVal reflect.Value
+	if input != nil {
+		inputVal = reflect.ValueOf(input)
+
+		// We need to check here if input is a typed nil. Typed nils won't
+		// match the "input == nil" below so we check that here.
+		if inputVal.Kind() == reflect.Ptr && inputVal.IsNil() {
+			input = nil
+		}
+	}
+
+	if input == nil {
+		// If the data is nil, then we don't set anything, unless ZeroFields is set
+		// to true.
+		if d.config.ZeroFields {
+			outVal.Set(reflect.Zero(outVal.Type()))
+
+			if d.config.Metadata != nil && name != "" {
+				d.config.Metadata.Keys = append(d.config.Metadata.Keys, name)
+			}
+		}
+		return nil
+	}
+
+	if !inputVal.IsValid() {
+		// If the input value is invalid, then we just set the value
+		// to be the zero value.
+		outVal.Set(reflect.Zero(outVal.Type()))
+		if d.config.Metadata != nil && name != "" {
+			d.config.Metadata.Keys = append(d.config.Metadata.Keys, name)
+		}
+		return nil
+	}
+
+	if d.config.DecodeHook != nil {
+		// We have a DecodeHook, so let's pre-process the input.
+		var err error
+		input, err = DecodeHookExec(
+			d.config.DecodeHook,
+			inputVal.Type(), outVal.Type(), input)
+		if err != nil {
+			return fmt.Errorf("error decoding '%s': %s", name, err)
+		}
+	}
+
+	var err error
+	outputKind := getKind(outVal)
+	switch outputKind {
+	case reflect.Bool:
+		err = d.decodeBool(name, input, outVal)
+	case reflect.Interface:
+		err = d.decodeBasic(name, input, outVal)
+	case reflect.String:
+		err = d.decodeString(name, input, outVal)
+	case reflect.Int:
+		err = d.decodeInt(name, input, outVal)
+	case reflect.Uint:
+		err = d.decodeUint(name, input, outVal)
+	case reflect.Float32:
+		err = d.decodeFloat(name, input, outVal)
+	case reflect.Struct:
+		err = d.decodeStruct(name, input, outVal)
+	case reflect.Map:
+		err = d.decodeMap(name, input, outVal)
+	case reflect.Ptr:
+		err = d.decodePtr(name, input, outVal)
+	case reflect.Slice:
+		err = d.decodeSlice(name, input, outVal)
+	case reflect.Array:
+		err = d.decodeArray(name, input, outVal)
+	case reflect.Func:
+		err = d.decodeFunc(name, input, outVal)
+	default:
+		// If we reached this point then we weren't able to decode it
+		return fmt.Errorf("%s: unsupported type: %s", name, outputKind)
+	}
+
+	// If we reached here, then we successfully decoded SOMETHING, so
+	// mark the key as used if we're tracking metainput.
+	if d.config.Metadata != nil && name != "" {
+		d.config.Metadata.Keys = append(d.config.Metadata.Keys, name)
+	}
+
+	return err
+}
+
+// This decodes a basic type (bool, int, string, etc.) and sets the
+// value to "data" of that type.
+func (d *Decoder) decodeBasic(name string, data interface{}, val reflect.Value) error {
+	if val.IsValid() && val.Elem().IsValid() {
+		return d.decode(name, data, val.Elem())
+	}
+
+	dataVal := reflect.ValueOf(data)
+
+	// If the input data is a pointer, and the assigned type is the dereference
+	// of that exact pointer, then indirect it so that we can assign it.
+	// Example: *string to string
+	if dataVal.Kind() == reflect.Ptr && dataVal.Type().Elem() == val.Type() {
+		dataVal = reflect.Indirect(dataVal)
+	}
+
+	if !dataVal.IsValid() {
+		dataVal = reflect.Zero(val.Type())
+	}
+
+	dataValType := dataVal.Type()
+	if !dataValType.AssignableTo(val.Type()) {
+		return fmt.Errorf(
+			"'%s' expected type '%s', got '%s'",
+			name, val.Type(), dataValType)
+	}
+
+	val.Set(dataVal)
+	return nil
+}
+
+func (d *Decoder) decodeString(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataKind := getKind(dataVal)
+
+	converted := true
+	switch {
+	case dataKind == reflect.String:
+		val.SetString(dataVal.String())
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetString("1")
+		} else {
+			val.SetString("0")
+		}
+	case dataKind == reflect.Int && d.config.WeaklyTypedInput:
+		val.SetString(strconv.FormatInt(dataVal.Int(), 10))
+	case dataKind == reflect.Uint && d.config.WeaklyTypedInput:
+		val.SetString(strconv.FormatUint(dataVal.Uint(), 10))
+	case dataKind == reflect.Float32 && d.config.WeaklyTypedInput:
+		val.SetString(strconv.FormatFloat(dataVal.Float(), 'f', -1, 64))
+	case dataKind == reflect.Slice && d.config.WeaklyTypedInput,
+		dataKind == reflect.Array && d.config.WeaklyTypedInput:
+		dataType := dataVal.Type()
+		elemKind := dataType.Elem().Kind()
+		switch elemKind {
+		case reflect.Uint8:
+			var uints []uint8
+			if dataKind == reflect.Array {
+				uints = make([]uint8, dataVal.Len(), dataVal.Len())
+				for i := range uints {
+					uints[i] = dataVal.Index(i).Interface().(uint8)
+				}
+			} else {
+				uints = dataVal.Interface().([]uint8)
+			}
+			val.SetString(string(uints))
+		default:
+			converted = false
+		}
+	default:
+		converted = false
+	}
+
+	if !converted {
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataKind := getKind(dataVal)
+	dataType := dataVal.Type()
+
+	switch {
+	case dataKind == reflect.Int:
+		val.SetInt(dataVal.Int())
+	case dataKind == reflect.Uint:
+		val.SetInt(int64(dataVal.Uint()))
+	case dataKind == reflect.Float32:
+		val.SetInt(int64(dataVal.Float()))
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetInt(1)
+		} else {
+			val.SetInt(0)
+		}
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		i, err := strconv.ParseInt(dataVal.String(), 0, val.Type().Bits())
+		if err == nil {
+			val.SetInt(i)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as int: %s", name, err)
+		}
+	case dataType.PkgPath() == "encoding/json" && dataType.Name() == "Number":
+		jn := data.(json.Number)
+		i, err := jn.Int64()
+		if err != nil {
+			return fmt.Errorf(
+				"error decoding json.Number into %s: %s", name, err)
+		}
+		val.SetInt(i)
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataKind := getKind(dataVal)
+
+	switch {
+	case dataKind == reflect.Int:
+		i := dataVal.Int()
+		if i < 0 && !d.config.WeaklyTypedInput {
+			return fmt.Errorf("cannot parse '%s', %d overflows uint",
+				name, i)
+		}
+		val.SetUint(uint64(i))
+	case dataKind == reflect.Uint:
+		val.SetUint(dataVal.Uint())
+	case dataKind == reflect.Float32:
+		f := dataVal.Float()
+		if f < 0 && !d.config.WeaklyTypedInput {
+			return fmt.Errorf("cannot parse '%s', %f overflows uint",
+				name, f)
+		}
+		val.SetUint(uint64(f))
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetUint(1)
+		} else {
+			val.SetUint(0)
+		}
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		i, err := strconv.ParseUint(dataVal.String(), 0, val.Type().Bits())
+		if err == nil {
+			val.SetUint(i)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as uint: %s", name, err)
+		}
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeBool(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataKind := getKind(dataVal)
+
+	switch {
+	case dataKind == reflect.Bool:
+		val.SetBool(dataVal.Bool())
+	case dataKind == reflect.Int && d.config.WeaklyTypedInput:
+		val.SetBool(dataVal.Int() != 0)
+	case dataKind == reflect.Uint && d.config.WeaklyTypedInput:
+		val.SetBool(dataVal.Uint() != 0)
+	case dataKind == reflect.Float32 && d.config.WeaklyTypedInput:
+		val.SetBool(dataVal.Float() != 0)
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		b, err := strconv.ParseBool(dataVal.String())
+		if err == nil {
+			val.SetBool(b)
+		} else if dataVal.String() == "" {
+			val.SetBool(false)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as bool: %s", name, err)
+		}
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeFloat(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataKind := getKind(dataVal)
+	dataType := dataVal.Type()
+
+	switch {
+	case dataKind == reflect.Int:
+		val.SetFloat(float64(dataVal.Int()))
+	case dataKind == reflect.Uint:
+		val.SetFloat(float64(dataVal.Uint()))
+	case dataKind == reflect.Float32:
+		val.SetFloat(dataVal.Float())
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetFloat(1)
+		} else {
+			val.SetFloat(0)
+		}
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		f, err := strconv.ParseFloat(dataVal.String(), val.Type().Bits())
+		if err == nil {
+			val.SetFloat(f)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as float: %s", name, err)
+		}
+	case dataType.PkgPath() == "encoding/json" && dataType.Name() == "Number":
+		jn := data.(json.Number)
+		i, err := jn.Float64()
+		if err != nil {
+			return fmt.Errorf(
+				"error decoding json.Number into %s: %s", name, err)
+		}
+		val.SetFloat(i)
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeMap(name string, data interface{}, val reflect.Value) error {
+	valType := val.Type()
+	valKeyType := valType.Key()
+	valElemType := valType.Elem()
+
+	// By default we overwrite keys in the current map
+	valMap := val
+
+	// If the map is nil or we're purposely zeroing fields, make a new map
+	if valMap.IsNil() || d.config.ZeroFields {
+		// Make a new map to hold our result
+		mapType := reflect.MapOf(valKeyType, valElemType)
+		valMap = reflect.MakeMap(mapType)
+	}
+
+	// Check input type and based on the input type jump to the proper func
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	switch dataVal.Kind() {
+	case reflect.Map:
+		return d.decodeMapFromMap(name, dataVal, val, valMap)
+
+	case reflect.Struct:
+		return d.decodeMapFromStruct(name, dataVal, val, valMap)
+
+	case reflect.Array, reflect.Slice:
+		if d.config.WeaklyTypedInput {
+			return d.decodeMapFromSlice(name, dataVal, val, valMap)
+		}
+
+		fallthrough
+
+	default:
+		return fmt.Errorf("'%s' expected a map, got '%s'", name, dataVal.Kind())
+	}
+}
+
+func (d *Decoder) decodeMapFromSlice(name string, dataVal reflect.Value, val reflect.Value, valMap reflect.Value) error {
+	// Special case for BC reasons (covered by tests)
+	if dataVal.Len() == 0 {
+		val.Set(valMap)
+		return nil
+	}
+
+	for i := 0; i < dataVal.Len(); i++ {
+		err := d.decode(
+			fmt.Sprintf("%s[%d]", name, i),
+			dataVal.Index(i).Interface(), val)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeMapFromMap(name string, dataVal reflect.Value, val reflect.Value, valMap reflect.Value) error {
+	valType := val.Type()
+	valKeyType := valType.Key()
+	valElemType := valType.Elem()
+
+	// Accumulate errors
+	errors := make([]string, 0)
+
+	// If the input data is empty, then we just match what the input data is.
+	if dataVal.Len() == 0 {
+		if dataVal.IsNil() {
+			if !val.IsNil() {
+				val.Set(dataVal)
+			}
+		} else {
+			// Set to empty allocated value
+			val.Set(valMap)
+		}
+
+		return nil
+	}
+
+	for _, k := range dataVal.MapKeys() {
+		fieldName := fmt.Sprintf("%s[%s]", name, k)
+
+		// First decode the key into the proper type
+		currentKey := reflect.Indirect(reflect.New(valKeyType))
+		if err := d.decode(fieldName, k.Interface(), currentKey); err != nil {
+			errors = appendErrors(errors, err)
+			continue
+		}
+
+		// Next decode the data into the proper type
+		v := dataVal.MapIndex(k).Interface()
+		currentVal := reflect.Indirect(reflect.New(valElemType))
+		if err := d.decode(fieldName, v, currentVal); err != nil {
+			errors = appendErrors(errors, err)
+			continue
+		}
+
+		valMap.SetMapIndex(currentKey, currentVal)
+	}
+
+	// Set the built up map to the value
+	val.Set(valMap)
+
+	// If we had errors, return those
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val reflect.Value, valMap reflect.Value) error {
+	typ := dataVal.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		// Get the StructField first since this is a cheap operation. If the
+		// field is unexported, then ignore it.
+		f := typ.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+
+		// Next get the actual value of this field and verify it is assignable
+		// to the map value.
+		v := dataVal.Field(i)
+		if !v.Type().AssignableTo(valMap.Type().Elem()) {
+			return fmt.Errorf("cannot assign type '%s' to map value field of type '%s'", v.Type(), valMap.Type().Elem())
+		}
+
+		tagValue := f.Tag.Get(d.config.TagName)
+		tagParts := strings.Split(tagValue, ",")
+
+		// Determine the name of the key in the map
+		keyName := f.Name
+		if tagParts[0] != "" {
+			if tagParts[0] == "-" {
+				continue
+			}
+			keyName = tagParts[0]
+		}
+
+		// If "squash" is specified in the tag, we squash the field down.
+		squash := false
+		for _, tag := range tagParts[1:] {
+			if tag == "squash" {
+				squash = true
+				break
+			}
+		}
+		if squash && v.Kind() != reflect.Struct {
+			return fmt.Errorf("cannot squash non-struct type '%s'", v.Type())
+		}
+
+		switch v.Kind() {
+		// this is an embedded struct, so handle it differently
+		case reflect.Struct:
+			x := reflect.New(v.Type())
+			x.Elem().Set(v)
+
+			vType := valMap.Type()
+			vKeyType := vType.Key()
+			vElemType := vType.Elem()
+			mType := reflect.MapOf(vKeyType, vElemType)
+			vMap := reflect.MakeMap(mType)
+
+			err := d.decode(keyName, x.Interface(), vMap)
+			if err != nil {
+				return err
+			}
+
+			if squash {
+				for _, k := range vMap.MapKeys() {
+					valMap.SetMapIndex(k, vMap.MapIndex(k))
+				}
+			} else {
+				valMap.SetMapIndex(reflect.ValueOf(keyName), vMap)
+			}
+
+		default:
+			valMap.SetMapIndex(reflect.ValueOf(keyName), v)
+		}
+	}
+
+	if val.CanAddr() {
+		val.Set(valMap)
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodePtr(name string, data interface{}, val reflect.Value) error {
+	// If the input data is nil, then we want to just set the output
+	// pointer to be nil as well.
+	isNil := data == nil
+	if !isNil {
+		switch v := reflect.Indirect(reflect.ValueOf(data)); v.Kind() {
+		case reflect.Chan,
+			reflect.Func,
+			reflect.Interface,
+			reflect.Map,
+			reflect.Ptr,
+			reflect.Slice:
+			isNil = v.IsNil()
+		}
+	}
+	if isNil {
+		if !val.IsNil() && val.CanSet() {
+			nilValue := reflect.New(val.Type()).Elem()
+			val.Set(nilValue)
+		}
+
+		return nil
+	}
+
+	// Create an element of the concrete (non pointer) type and decode
+	// into that. Then set the value of the pointer to this type.
+	valType := val.Type()
+	valElemType := valType.Elem()
+	if val.CanSet() {
+		realVal := val
+		if realVal.IsNil() || d.config.ZeroFields {
+			realVal = reflect.New(valElemType)
+		}
+
+		if err := d.decode(name, data, reflect.Indirect(realVal)); err != nil {
+			return err
+		}
+
+		val.Set(realVal)
+	} else {
+		if err := d.decode(name, data, reflect.Indirect(val)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Decoder) decodeFunc(name string, data interface{}, val reflect.Value) error {
+	// Create an element of the concrete (non pointer) type and decode
+	// into that. Then set the value of the pointer to this type.
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	if val.Type() != dataVal.Type() {
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+	val.Set(dataVal)
+	return nil
+}
+
+func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataValKind := dataVal.Kind()
+	valType := val.Type()
+	valElemType := valType.Elem()
+	sliceType := reflect.SliceOf(valElemType)
+
+	valSlice := val
+	if valSlice.IsNil() || d.config.ZeroFields {
+		if d.config.WeaklyTypedInput {
+			switch {
+			// Slice and array we use the normal logic
+			case dataValKind == reflect.Slice, dataValKind == reflect.Array:
+				break
+
+			// Empty maps turn into empty slices
+			case dataValKind == reflect.Map:
+				if dataVal.Len() == 0 {
+					val.Set(reflect.MakeSlice(sliceType, 0, 0))
+					return nil
+				}
+				// Create slice of maps of other sizes
+				return d.decodeSlice(name, []interface{}{data}, val)
+
+			case dataValKind == reflect.String && valElemType.Kind() == reflect.Uint8:
+				return d.decodeSlice(name, []byte(dataVal.String()), val)
+
+			// All other types we try to convert to the slice type
+			// and "lift" it into it. i.e. a string becomes a string slice.
+			default:
+				// Just re-try this function with data as a slice.
+				return d.decodeSlice(name, []interface{}{data}, val)
+			}
+		}
+
+		// Check input type
+		if dataValKind != reflect.Array && dataValKind != reflect.Slice {
+			return fmt.Errorf(
+				"'%s': source data must be an array or slice, got %s", name, dataValKind)
+
+		}
+
+		// If the input value is empty, then don't allocate since non-nil != nil
+		if dataVal.Len() == 0 {
+			return nil
+		}
+
+		// Make a new slice to hold our result, same size as the original data.
+		valSlice = reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
+	}
+
+	// Accumulate any errors
+	errors := make([]string, 0)
+
+	for i := 0; i < dataVal.Len(); i++ {
+		currentData := dataVal.Index(i).Interface()
+		for valSlice.Len() <= i {
+			valSlice = reflect.Append(valSlice, reflect.Zero(valElemType))
+		}
+		currentField := valSlice.Index(i)
+
+		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		if err := d.decode(fieldName, currentData, currentField); err != nil {
+			errors = appendErrors(errors, err)
+		}
+	}
+
+	// Finally, set the value to the slice we built up
+	val.Set(valSlice)
+
+	// If there were errors, we return those
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeArray(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataValKind := dataVal.Kind()
+	valType := val.Type()
+	valElemType := valType.Elem()
+	arrayType := reflect.ArrayOf(valType.Len(), valElemType)
+
+	valArray := val
+
+	if valArray.Interface() == reflect.Zero(valArray.Type()).Interface() || d.config.ZeroFields {
+		// Check input type
+		if dataValKind != reflect.Array && dataValKind != reflect.Slice {
+			if d.config.WeaklyTypedInput {
+				switch {
+				// Empty maps turn into empty arrays
+				case dataValKind == reflect.Map:
+					if dataVal.Len() == 0 {
+						val.Set(reflect.Zero(arrayType))
+						return nil
+					}
+
+				// All other types we try to convert to the array type
+				// and "lift" it into it. i.e. a string becomes a string array.
+				default:
+					// Just re-try this function with data as a slice.
+					return d.decodeArray(name, []interface{}{data}, val)
+				}
+			}
+
+			return fmt.Errorf(
+				"'%s': source data must be an array or slice, got %s", name, dataValKind)
+
+		}
+		if dataVal.Len() > arrayType.Len() {
+			return fmt.Errorf(
+				"'%s': expected source data to have length less or equal to %d, got %d", name, arrayType.Len(), dataVal.Len())
+
+		}
+
+		// Make a new array to hold our result, same size as the original data.
+		valArray = reflect.New(arrayType).Elem()
+	}
+
+	// Accumulate any errors
+	errors := make([]string, 0)
+
+	for i := 0; i < dataVal.Len(); i++ {
+		currentData := dataVal.Index(i).Interface()
+		currentField := valArray.Index(i)
+
+		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		if err := d.decode(fieldName, currentData, currentField); err != nil {
+			errors = appendErrors(errors, err)
+		}
+	}
+
+	// Finally, set the value to the array we built up
+	val.Set(valArray)
+
+	// If there were errors, we return those
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+
+	// If the type of the value to write to and the data match directly,
+	// then we just set it directly instead of recursing into the structure.
+	if dataVal.Type() == val.Type() {
+		val.Set(dataVal)
+		return nil
+	}
+
+	dataValKind := dataVal.Kind()
+	switch dataValKind {
+	case reflect.Map:
+		return d.decodeStructFromMap(name, dataVal, val)
+
+	case reflect.Struct:
+		// Not the most efficient way to do this but we can optimize later if
+		// we want to. To convert from struct to struct we go to map first
+		// as an intermediary.
+		m := make(map[string]interface{})
+		mval := reflect.Indirect(reflect.ValueOf(&m))
+		if err := d.decodeMapFromStruct(name, dataVal, mval, mval); err != nil {
+			return err
+		}
+
+		result := d.decodeStructFromMap(name, mval, val)
+		return result
+
+	default:
+		return fmt.Errorf("'%s' expected a map, got '%s'", name, dataVal.Kind())
+	}
+}
+
+func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) error {
+	dataValType := dataVal.Type()
+	if kind := dataValType.Key().Kind(); kind != reflect.String && kind != reflect.Interface {
+		return fmt.Errorf(
+			"'%s' needs a map with string keys, has '%s' keys",
+			name, dataValType.Key().Kind())
+	}
+
+	dataValKeys := make(map[reflect.Value]struct{})
+	dataValKeysUnused := make(map[interface{}]struct{})
+	for _, dataValKey := range dataVal.MapKeys() {
+		dataValKeys[dataValKey] = struct{}{}
+		dataValKeysUnused[dataValKey.Interface()] = struct{}{}
+	}
+
+	errors := make([]string, 0)
+
+	// This slice will keep track of all the structs we'll be decoding.
+	// There can be more than one struct if there are embedded structs
+	// that are squashed.
+	structs := make([]reflect.Value, 1, 5)
+	structs[0] = val
+
+	// Compile the list of all the fields that we're going to be decoding
+	// from all the structs.
+	type field struct {
+		field reflect.StructField
+		val   reflect.Value
+	}
+	fields := []field{}
+	for len(structs) > 0 {
+		structVal := structs[0]
+		structs = structs[1:]
+
+		structType := structVal.Type()
+
+		for i := 0; i < structType.NumField(); i++ {
+			fieldType := structType.Field(i)
+			fieldKind := fieldType.Type.Kind()
+
+			// If "squash" is specified in the tag, we squash the field down.
+			squash := false
+			tagParts := strings.Split(fieldType.Tag.Get(d.config.TagName), ",")
+			for _, tag := range tagParts[1:] {
+				if tag == "squash" {
+					squash = true
+					break
+				}
+			}
+
+			if squash {
+				if fieldKind != reflect.Struct {
+					errors = appendErrors(errors,
+						fmt.Errorf("%s: unsupported type for squash: %s", fieldType.Name, fieldKind))
+				} else {
+					structs = append(structs, structVal.FieldByName(fieldType.Name))
+				}
+				continue
+			}
+
+			// Normal struct field, store it away
+			fields = append(fields, field{fieldType, structVal.Field(i)})
+		}
+	}
+
+	// for fieldType, field := range fields {
+	for _, f := range fields {
+		field, fieldValue := f.field, f.val
+		fieldName := field.Name
+
+		tagValue := field.Tag.Get(d.config.TagName)
+		tagValue = strings.SplitN(tagValue, ",", 2)[0]
+		if tagValue != "" {
+			fieldName = tagValue
+		}
+
+		rawMapKey := reflect.ValueOf(fieldName)
+		rawMapVal := dataVal.MapIndex(rawMapKey)
+		if !rawMapVal.IsValid() {
+			// Do a slower search by iterating over each key and
+			// doing case-insensitive search.
+			for dataValKey := range dataValKeys {
+				mK, ok := dataValKey.Interface().(string)
+				if !ok {
+					// Not a string key
+					continue
+				}
+
+				if strings.EqualFold(mK, fieldName) {
+					rawMapKey = dataValKey
+					rawMapVal = dataVal.MapIndex(dataValKey)
+					break
+				}
+			}
+
+			if !rawMapVal.IsValid() {
+				// There was no matching key in the map for the value in
+				// the struct. Just ignore.
+				continue
+			}
+		}
+
+		// Delete the key we're using from the unused map so we stop tracking
+		delete(dataValKeysUnused, rawMapKey.Interface())
+
+		if !fieldValue.IsValid() {
+			// This should never happen
+			panic("field is not valid")
+		}
+
+		// If we can't set the field, then it is unexported or something,
+		// and we just continue onwards.
+		if !fieldValue.CanSet() {
+			continue
+		}
+
+		// If the name is empty string, then we're at the root, and we
+		// don't dot-join the fields.
+		if name != "" {
+			fieldName = fmt.Sprintf("%s.%s", name, fieldName)
+		}
+
+		if err := d.decode(fieldName, rawMapVal.Interface(), fieldValue); err != nil {
+			errors = appendErrors(errors, err)
+		}
+	}
+
+	if d.config.ErrorUnused && len(dataValKeysUnused) > 0 {
+		keys := make([]string, 0, len(dataValKeysUnused))
+		for rawKey := range dataValKeysUnused {
+			keys = append(keys, rawKey.(string))
+		}
+		sort.Strings(keys)
+
+		err := fmt.Errorf("'%s' has invalid keys: %s", name, strings.Join(keys, ", "))
+		errors = appendErrors(errors, err)
+	}
+
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	// Add the unused keys to the list of unused keys if we're tracking metadata
+	if d.config.Metadata != nil {
+		for rawKey := range dataValKeysUnused {
+			key := rawKey.(string)
+			if name != "" {
+				key = fmt.Sprintf("%s.%s", name, key)
+			}
+
+			d.config.Metadata.Unused = append(d.config.Metadata.Unused, key)
+		}
+	}
+
+	return nil
+}
+
+func getKind(val reflect.Value) reflect.Kind {
+	kind := val.Kind()
+
+	switch {
+	case kind >= reflect.Int && kind <= reflect.Int64:
+		return reflect.Int
+	case kind >= reflect.Uint && kind <= reflect.Uint64:
+		return reflect.Uint
+	case kind >= reflect.Float32 && kind <= reflect.Float64:
+		return reflect.Float32
+	default:
+		return kind
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,6 +46,9 @@ github.com/imdario/mergo
 github.com/json-iterator/go
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
+# github.com/mitchellh/mapstructure v1.1.2
+## explicit
+github.com/mitchellh/mapstructure
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1


### PR DESCRIPTION
In order to make cluster machine approver work with CAPI and MAPI machines, I converted the code to use unstructured. The API group is passed as a CLI argument and defaults to MAPI. The unstructured approach is similar to what is done in autoscaler.