### PR TITLE
Bug 1952282: Ensure serving certs requeued

### DIFF
--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -195,7 +195,8 @@ func authorizeCSR(
 	if !ok {
 		klog.Errorf("%v: Serving Cert: No target machine for node %q", req.Name, nodeAsking)
 		//TODO: set annotation/emit event here.
-		return false, nil
+		// Return error so we requeue in case we're racing with node linker.
+		return false, fmt.Errorf("Unable to find machine for node")
 	}
 
 	// SAN checks for both DNS and IPs, e.g.,

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -644,7 +644,7 @@ func Test_authorizeCSR(t *testing.T) {
 				},
 				csr: goodCSR,
 			},
-			wantErr:   "",
+			wantErr:   "Unable to find machine for node",
 			authorize: false,
 		},
 		{
@@ -2225,7 +2225,7 @@ func Test_authorizeCSR(t *testing.T) {
 				ca:            []*x509.Certificate{parseCert(t, differentCert)},
 				kubeletServer: fakeResponder(t, fmt.Sprintf("%s:%v", defaultAddr, defaultPort+1), differentCert, differentKey),
 			},
-			wantErr:   "",
+			wantErr:   "Unable to find machine for node",
 			authorize: false,
 		},
 	}


### PR DESCRIPTION
This commit ensures serving certs are requeued in case the node link
controller has not yet updated the machine object.