### PR TITLE
[OCPCLOUD-1175] Ensure must-gather tracks related objects on failures

### DIFF
--- a/manifests/05-clusteroperator.yaml
+++ b/manifests/05-clusteroperator.yaml
@@ -8,6 +8,13 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec: {}
 status:
+  relatedObjects:
+  - group: ""
+    name: openshift-cluster-machine-approver
+    resource: namespaces
+  - group: certificates.k8s.io
+    name: ""
+    resource: certificatesigningrequests
   versions:
     - name: operator
       version: "0.0.1-snapshot"


### PR DESCRIPTION
To ensure that must-gather can run correctly when CMA has not started properly, we can prepopulate the relatedObjects field. CVO will pre-create this resource and must-gather will know which resources to pull even if CMA never set these itself