### PR TITLE
podsecurity: enforce privileged for openshift-cluster-machine-approver namespace

### DIFF
--- a/manifests/00-ns.yaml
+++ b/manifests/00-ns.yaml
@@ -12,3 +12,6 @@ metadata:
     openshift.io/run-level: "0"
     # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
     openshift.io/cluster-monitoring: "true" 
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-cluster-machine-approver ` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 
