### PR TITLE
Bug 2010359: add summary and description to alerts

### DIFF
--- a/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
+++ b/manifests/0000_90_cluster-machine-approver_04_alertrules.yaml
@@ -21,4 +21,10 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: "max pending CSRs threshold reached."
+            summary: "max pending CSRs threshold reached."
+            description: |
+              The number of pending CertificateSigningRequests has exceeded the
+              maximum threshold (current number of machine + 100). Check the
+              pending CSRs to determine which machines need approval, also check
+              that the nodelink controller is running in the openshift-machine-api
+              namespace.


### PR DESCRIPTION
this brings the alerts into compliance with the style guide for
openshift.

ref:
https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#style-guide