### PR TITLE
Bug 2019754: Ensure pending CSR count is valid post approval

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -130,7 +130,16 @@ func (m *CertificateApprover) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	for _, csr := range csrs.Items {
 		if csr.Name == req.Name {
-			return reconcile.Result{}, m.reconcileCSR(csr, machines)
+			if err := m.reconcileCSR(csr, machines); err != nil {
+				return reconcile.Result{}, fmt.Errorf("could not reconcile CSR: %v", err)
+			}
+
+			// Reconcile the limits at the end of a reconcile so that the currently
+			// pending CSRs metric has an up to date value if we approved a CSR.
+			// When an error occurs, we requeue and so update the limits on the
+			// next reconcile.
+			// Don't use a cached client here else we may not have up to date CSRs.
+			return reconcile.Result{}, reconcileLimitsUncached(m.RestCfg, csr.Name, machines)
 		}
 	}
 
@@ -151,6 +160,24 @@ func reconcileLimits(csrName string, machines *machinev1.MachineList, csrs *cert
 	}
 
 	return false
+}
+
+// reconcileLimitsUncached is used to update the limits using an uncached certificates list.
+// This is used at the end of the approval process to ensure that the limits (and therefore)
+// the metrics are always up to date.
+func reconcileLimitsUncached(cfg *rest.Config, csrName string, machines *machinev1.MachineList) error {
+	certClient, err := certificatesv1client.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("could not initialise certificates client: %v", err)
+	}
+
+	certificates, err := certClient.CertificateSigningRequests().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("could not list CSRs: %v", err)
+	}
+
+	reconcileLimits(csrName, machines, certificates)
+	return nil
 }
 
 func (m *CertificateApprover) reconcileCSR(csr certificatesv1.CertificateSigningRequest, machines *machinev1.MachineList) error {


### PR DESCRIPTION
This is a manual cherry pick of #135

> Currently, we reconcile the limits (which the metrics are sourced from) at the beginning of the reconcile loop.
> 
> We only reconcile when there is a pending CSR.
> 
> So at the beginning of the reconcile loop, there is 1 pending CSR, we set the metric to 1.
> We then approve the CSR, now there are no pending CSRs, so we don't have anything to reconcile.
> With no reconciles happening, we never update the metric value, so it stays at 1.
>
> This PR adjusts so that once we have reconciled, assuming it was successful, we re-reconcile the limits (metrics) to ensure they are still up to date. If we made an approval during the reconcileCSR this should now be accounted for
during the metric collection.
>
> If there are any errors throughout this, we don't need to reconcile the limits as this will be handled when we requeue anyway