### PR TITLE
Add metric to count old pending CSRs

### DIFF
--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -2747,9 +2747,10 @@ func TestRecentlyPendingCSRs(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		csrs          []certificatesv1.CertificateSigningRequest
-		expectPending int
+		name             string
+		csrs             []certificatesv1.CertificateSigningRequest
+		expectPending    int
+		expectOldPending int
 	}{
 		{
 			name:          "recently pending csr",
@@ -2762,9 +2763,10 @@ func TestRecentlyPendingCSRs(t *testing.T) {
 			expectPending: 0,
 		},
 		{
-			name:          "pending past approval time",
-			csrs:          []certificatesv1.CertificateSigningRequest{createdAt(pastApprovalTime, pendingCSR)},
-			expectPending: 0,
+			name:             "pending past approval time",
+			csrs:             []certificatesv1.CertificateSigningRequest{createdAt(pastApprovalTime, pendingCSR)},
+			expectPending:    0,
+			expectOldPending: 1,
 		},
 		{
 			name:          "pending before approval time",
@@ -2783,14 +2785,19 @@ func TestRecentlyPendingCSRs(t *testing.T) {
 				createdAt(preApprovalTime, pendingCSR),
 				createdAt(pastApprovalTime, pendingCSR),
 			},
-			expectPending: 2,
+			expectPending:    2,
+			expectOldPending: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if pending := recentlyPendingCSRs(tt.csrs); pending != tt.expectPending {
+			pending, oldPending := pendingCSRsByAge(tt.csrs)
+			if pending != tt.expectPending {
 				t.Errorf("Expected %v pending CSRs, got: %v", tt.expectPending, pending)
+			}
+			if oldPending != tt.expectOldPending {
+				t.Errorf("Expected %v old pending CSRs, got: %v", tt.expectOldPending, oldPending)
 			}
 		})
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,6 +15,8 @@ const DefaultMetricsPort = ":9191"
 var (
 	// CurrentPendingCSRCountDesc is a metric to report count of the pending csr in the cluster
 	CurrentPendingCSRCountDesc = prometheus.NewDesc("mapi_current_pending_csr", "Count of pending CSRs at the cluster level", nil, nil)
+	// OldPendingCSRCountDesc is a metric to report the count of pending CSRs which have aged out of the approval window
+	OldPendingCSRCountDesc = prometheus.NewDesc("mapi_old_pending_csr", "Count of pending CSRs which are now too old to be approved", nil, nil)
 	// MaxPendingCSRDesc is a metric to report threshold value of the pending csr beyond which csr will be ignored
 	MaxPendingCSRDesc = prometheus.NewDesc("mapi_max_pending_csr", "Threshold value of the pending CSRs beyond which any new CSR requests will be ignored ", nil, nil)
 )
@@ -34,12 +36,14 @@ func (mc *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 // Describe implements the prometheus.Collector interface.
 func (mc MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- CurrentPendingCSRCountDesc
+	ch <- OldPendingCSRCountDesc
 	ch <- MaxPendingCSRDesc
 }
 
 // Collect implements the prometheus.Collector interface.
 func (mc MetricsCollector) collectMetrics(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(CurrentPendingCSRCountDesc, prometheus.GaugeValue, float64(atomic.LoadUint32(&controller.PendingCSRs)))
+	ch <- prometheus.MustNewConstMetric(OldPendingCSRCountDesc, prometheus.GaugeValue, float64(atomic.LoadUint32(&controller.OldPendingCSRs)))
 	ch <- prometheus.MustNewConstMetric(MaxPendingCSRDesc, prometheus.GaugeValue, float64(atomic.LoadUint32(&controller.MaxPendingCSRs)))
 	klog.V(4).Infof("collectMetrics exit")
 }


### PR DESCRIPTION
Currently, we ignore any CSRs that are too old for the machine approver to approve them, based on [this conversation](https://coreos.slack.com/archives/CBZHF4DHC/p1638410837249600) it was asked if we could include a new metric to count the old CSRs as well.

This should mean now that you can determine the three states of CSRs, too new (via a calculation), within the time window, and too old. With the current metrics, there is no way to determine the difference between CSRs that are too new or too old.