### PR TITLE
[config] Add disabling node server cert approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ automatically approves all CSRs.  This bootstrap service will end up approving
 the CSRs for the control plane nodes, while `cluster-machine-approver` will
 take over for future new CSRs from worker nodes.
 
-### Disabling Node Client CSR Approvals
+### Disabling Node CSR Approvals
 
-It is possible to disable node client CSR approvals completely.  This is done
-using a `ConfigMap` resource, as shown in [this PR
-comment](https://github.com/openshift/cluster-machine-approver/pull/26#issuecomment-492782189).
+It is possible to disable node client and server CSR approvals completely. This is done
+using a `ConfigMap` resource, as shown in in the example below. The `nodeClientCert` and 
+`nodeServerCert` options can be used indepedently or concurrently.
 
 ```yaml
 apiVersion: v1
@@ -62,6 +62,8 @@ metadata:
 data:
   config.yaml: |-
     nodeClientCert:
+      disabled: true
+    nodeServerCert:
       disabled: true
 ```
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -11,9 +11,14 @@ import (
 
 type ClusterMachineApproverConfig struct {
 	NodeClientCert NodeClientCert `json:"nodeClientCert,omitempty"`
+	NodeServerCert NodeServerCert `json:"nodeServerCert,omitempty"`
 }
 
 type NodeClientCert struct {
+	Disabled bool `json:"disabled,omitempty"`
+}
+
+type NodeServerCert struct {
 	Disabled bool `json:"disabled,omitempty"`
 }
 

--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -147,7 +147,7 @@ func authorizeCSR(
 
 	if isNodeClientCert(req, csr) {
 		if config.NodeClientCert.Disabled {
-			klog.Errorf("%v: CSR rejected as the flow is disabled", req.Name)
+			klog.Errorf("%v: CSR rejected as the node client cert flow is disabled", req.Name)
 			return false, fmt.Errorf("CSR %s for node client cert rejected as the flow is disabled", req.Name)
 		}
 		return authorizeNodeClientCSR(c, machines, req, csr)
@@ -155,6 +155,11 @@ func authorizeCSR(
 
 	klog.Infof("%v: CSR does not appear to be client csr", req.Name)
 	// node serving cert validation after this point
+
+	if config.NodeServerCert.Disabled {
+		klog.Errorf("%v: CSR rejected as the node server cert flow is disabled", req.Name)
+		return false, fmt.Errorf("CSR %s for node server cert rejected as the flow is disabled", req.Name)
+	}
 
 	nodeAsking, err := validateCSRContents(req, csr)
 	if nodeAsking == "" || err != nil {


### PR DESCRIPTION
This PR adds support to disable node server cert auto approvals.

One benefit of this is that the machine approver controller can be stopped from
automatically approving a node's server CSR when it is not the one who approved
the node's client CSR.