### PR TITLE
Bug 2028019: Account for large scale simultaneous renewal on UPI clusters

### DIFF
--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -2885,19 +2885,50 @@ func creationTimestamp(delta time.Duration) metav1.Time {
 }
 
 func TestGetMaxPending(t *testing.T) {
-	ml := []machinehandlerpkg.Machine{
+	testCases := []struct {
+		name        string
+		machines    []machinehandlerpkg.Machine
+		nodes       []corev1.Node
+		expectedMax int
+	}{
 		{
-			Status: machinehandlerpkg.MachineStatus{},
+			name: "with more machines than nodes",
+			machines: []machinehandlerpkg.Machine{
+				{},
+				{},
+				{},
+			},
+			nodes: []corev1.Node{
+				{},
+				{},
+			},
+			expectedMax: 3 + maxDiffBetweenPendingCSRsAndMachinesCount,
 		},
 		{
-			Status: machinehandlerpkg.MachineStatus{},
+			name: "with more nodes than machines",
+			machines: []machinehandlerpkg.Machine{
+				{},
+				{},
+				{},
+			},
+			nodes: []corev1.Node{
+				{},
+				{},
+				{},
+				{},
+			},
+			expectedMax: 4 + maxDiffBetweenPendingCSRsAndMachinesCount,
 		},
 	}
 
-	res := getMaxPending(ml)
-	expected := len(ml) + maxDiffBetweenPendingCSRsAndMachinesCount
-	if res != expected {
-		t.Errorf("getMaxPending returned incorrect value: %v, expect: %v", res, expected)
+	for _, tc := range testCases {
+		nodeList := &corev1.NodeList{
+			Items: tc.nodes,
+		}
+		res := getMaxPending(tc.machines, nodeList)
+		if res != tc.expectedMax {
+			t.Errorf("getMaxPending returned incorrect value: %v, expect: %v", res, tc.expectedMax)
+		}
 	}
 }
 


### PR DESCRIPTION
If more than 100 machines need to renew their certificates at once on a UPI cluster today, we exhaust the capacity limit set by the maxPending check. To allow renewal in these cases we need to account for how many Nodes have joined the cluster before we block the approvals