### PR TITLE
Make 'reject_expired' tests works in any time zone

### DIFF
--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -2386,8 +2386,8 @@ func Test_authorizeCSR(t *testing.T) {
 }
 
 func TestAuthorizeServingRenewal(t *testing.T) {
-	presetTimeCorrect := time.Now()
-	presetTimeExpired := time.Now().Add(-24 * time.Hour)
+	presetTimeCorrect := time.Now().UTC()
+	presetTimeExpired := time.Now().UTC().Add(-24 * time.Hour)
 
 	tests := []struct {
 		name        string
@@ -2479,8 +2479,8 @@ func TestAuthorizeServingRenewal(t *testing.T) {
 }
 
 func TestAuthorizeServingRenewalWithEgressIPs(t *testing.T) {
-	presetTimeCorrect := time.Now()
-	presetTimeExpired := time.Now().Add(-24 * time.Hour)
+	presetTimeCorrect := time.Now().UTC()
+	presetTimeExpired := time.Now().UTC().Add(-24 * time.Hour)
 	testNodeName := "test"
 
 	tests := []struct {


### PR DESCRIPTION
x509.CreateCertificate function casts validity time to utc under the hood
https://cs.opensource.google/go/go/+/refs/tags/go1.17.6:src/crypto/x509/x509.go;l=1538