### PR TITLE
Shrink csr_check_test.go size

### DIFF
--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -467,6 +467,41 @@ func Test_authorizeCSR(t *testing.T) {
 		return hostSubnet
 	}
 
+	var makeMachine = func(nodeName string, addresses ...corev1.NodeAddress) machinehandlerpkg.Machine {
+		if len(addresses) == 0 {
+			addresses = []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "127.0.0.1",
+				},
+				{
+					Type:    corev1.NodeExternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    corev1.NodeInternalDNS,
+					Address: "node1.local",
+				},
+				{
+					Type:    corev1.NodeExternalDNS,
+					Address: "node1",
+				},
+			}
+		}
+		var nodeRef *corev1.ObjectReference
+		if nodeName != "" {
+			nodeRef = &corev1.ObjectReference{
+				Name: nodeName,
+			}
+		}
+		return machinehandlerpkg.Machine{
+			Status: machinehandlerpkg.MachineStatus{
+				NodeRef:   nodeRef,
+				Addresses: addresses,
+			},
+		}
+	}
+
 	type args struct {
 		config        ClusterMachineApproverConfig
 		machines      []machinehandlerpkg.Machine
@@ -487,33 +522,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "ok",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -545,33 +554,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "no-node-prefix",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -594,33 +577,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "only-node-prefix",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -670,33 +627,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "missing-groups-1",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -718,33 +649,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "missing-groups-2",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -766,33 +671,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "extra-group",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -816,33 +695,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "wrong-group",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -865,33 +718,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usages-missing",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -912,33 +739,7 @@ func Test_authorizeCSR(t *testing.T) {
 		}, {
 			name: "usages-missing",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -961,33 +762,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usages-missing-1",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1009,33 +784,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usage-missing-2",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1057,33 +806,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "usage-extra",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1107,33 +830,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-cn",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1156,33 +853,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-cn-2",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1205,33 +876,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-no-o",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1254,33 +899,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "csr-extra-addr",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
 						Usages: []certificatesv1.KeyUsage{
@@ -1304,31 +923,12 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "csr-san-ip-mismatch",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.2",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
+					makeMachine("test", []corev1.NodeAddress{
+						{corev1.NodeInternalIP, "127.0.0.1"},
+						{corev1.NodeExternalIP, "10.0.0.2"},
+						{corev1.NodeExternalDNS, "node1"},
+						{corev1.NodeExternalDNS, "node1.local"},
+					}...),
 				},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -1353,31 +953,12 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "csr-san-dns-mismatch",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node2",
-								},
-							},
-						},
-					},
+					makeMachine("test", []corev1.NodeAddress{
+						{corev1.NodeInternalIP, "127.0.0.1"},
+						{corev1.NodeExternalIP, "10.0.0.1"},
+						{corev1.NodeExternalDNS, "node1.local"},
+						{corev1.NodeExternalDNS, "node2"},
+					}...),
 				},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -1403,26 +984,8 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "tigers",
-								},
-							},
-						},
-					},
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "tigers"}),
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -1448,16 +1011,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client extra O",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "bear",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "bear"}),
 				},
 				node: withName("bear", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1484,16 +1038,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client with DNS",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "monkey",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "monkey"}),
 				},
 				node: withName("monkey", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1520,16 +1065,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but extra usage",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1557,16 +1093,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but wrong usage",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1593,16 +1120,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but missing usage",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1628,16 +1146,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but wrong CN",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "zebra",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "zebra"}),
 				},
 				node: withName("zebra", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1664,16 +1173,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but wrong user",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1701,16 +1201,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but wrong user group",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1739,16 +1230,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but empty name",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1776,16 +1258,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but node exists",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1812,16 +1285,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but missing machine",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeExternalDNS, "panda"}),
 				},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -1847,17 +1311,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but machine has node ref",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{Name: "other"},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("other", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				req: &certificatesv1.CertificateSigningRequest{
 					Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -1888,26 +1342,8 @@ func Test_authorizeCSR(t *testing.T) {
 					},
 				},
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "tigers",
-								},
-							},
-						},
-					},
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "panda",
-								},
-							},
-						},
-					},
+					makeMachine("other", corev1.NodeAddress{corev1.NodeInternalDNS, "tigers"}),
+					makeMachine("other", corev1.NodeAddress{corev1.NodeInternalDNS, "panda"}),
 				},
 				node: withName("panda", defaultNode()),
 				req: &certificatesv1.CertificateSigningRequest{
@@ -1935,16 +1371,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good with proper timing",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "tigers",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "tigers"}),
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(2 * time.Minute),
@@ -1987,16 +1414,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good with proper timing 2",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "tigers",
-								},
-							},
-						},
-					},
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "tigers"}),
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(3 * time.Minute),
@@ -2039,16 +1457,7 @@ func Test_authorizeCSR(t *testing.T) {
 			name: "client good but CSR too early",
 			args: args{
 				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "tigers",
-								},
-							},
-						},
-					},
+					makeMachine("other", corev1.NodeAddress{corev1.NodeInternalDNS, "tigers"}),
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: creationTimestamp(3 * time.Minute),
@@ -2169,33 +1578,7 @@ func Test_authorizeCSR(t *testing.T) {
 		{
 			name: "successfull fallback to fresh approval",
 			args: args{
-				machines: []machinehandlerpkg.Machine{
-					{
-						Status: machinehandlerpkg.MachineStatus{
-							NodeRef: &corev1.ObjectReference{
-								Name: "test",
-							},
-							Addresses: []corev1.NodeAddress{
-								{
-									Type:    corev1.NodeInternalIP,
-									Address: "127.0.0.1",
-								},
-								{
-									Type:    corev1.NodeExternalIP,
-									Address: "10.0.0.1",
-								},
-								{
-									Type:    corev1.NodeInternalDNS,
-									Address: "node1.local",
-								},
-								{
-									Type:    corev1.NodeExternalDNS,
-									Address: "node1",
-								},
-							},
-						},
-					},
-				},
+				machines: []machinehandlerpkg.Machine{makeMachine("test")},
 				req: &certificatesv1.CertificateSigningRequest{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "renew",

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -37,6 +37,8 @@ var serverCertGood, serverKeyGood, rootCertGood string
 // Generated CRs, are populating within the init func
 var goodCSR, extraAddr, otherName, noNamePrefix, noGroup, clientGood, clientExtraO, clientWithDNS, clientWrongCN, clientEmptyName, emptyCSR string
 
+var presetTimeCorrect, presetTimeExpired time.Time
+
 const (
 	differentCert = `-----BEGIN CERTIFICATE-----
 MIIB6zCCAZGgAwIBAgIUNukOeYC/OJTuAHe8x0dZGxo/UPcwCgYIKoZIzj0EAwIw
@@ -78,6 +80,9 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	presetTimeCorrect = time.Now().UTC()
+	presetTimeExpired = time.Now().UTC().Add(-24 * time.Hour)
 
 	rootCertGood = string(rootCert)
 	serverCertGood = string(serverCert)
@@ -1547,9 +1552,6 @@ func Test_authorizeCSR(t *testing.T) {
 }
 
 func TestAuthorizeServingRenewal(t *testing.T) {
-	presetTimeCorrect := time.Now().UTC()
-	presetTimeExpired := time.Now().UTC().Add(-24 * time.Hour)
-
 	tests := []struct {
 		name        string
 		nodeName    string
@@ -1640,8 +1642,6 @@ func TestAuthorizeServingRenewal(t *testing.T) {
 }
 
 func TestAuthorizeServingRenewalWithEgressIPs(t *testing.T) {
-	presetTimeCorrect := time.Now().UTC()
-	presetTimeExpired := time.Now().UTC().Add(-24 * time.Hour)
 	testNodeName := "test"
 
 	tests := []struct {

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -10,12 +10,10 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"math/big"
 	"net"
 	"net/url"
 	"reflect"
-	"sort"
 	"testing"
 	"time"
 
@@ -35,6 +33,9 @@ import (
 
 // The following global test variables are populated within the init func
 var serverCertGood, serverKeyGood, rootCertGood string
+
+// Generated CRs, are populating within the init func
+var goodCSR, extraAddr, otherName, noNamePrefix, noGroup, clientGood, clientExtraO, clientWithDNS, clientWrongCN, clientEmptyName, emptyCSR string
 
 const (
 	differentCert = `-----BEGIN CERTIFICATE-----
@@ -56,278 +57,6 @@ MHcCAQEEIFU6aDkXYwx8YYtXd9AZPIst87daWX49Rzhxsd7D7UwroAoGCCqGSM49
 AwEHoUQDQgAErUDDpFwiP28p9TD3OSmDNXeTbDxeIHsY3iqoya6x3Gk6MIyQEDrJ
 SlwIRyqdMvo4Rc6/JUHQ67eXh1Cvy3w6Sg==
 -----END EC PRIVATE KEY-----
-`
-	goodCSR = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:test
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:node1, DNS:node1.local, IP Address:10.0.0.1, IP Address:127.0.0.1
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICszCCAZsCAQAwMjEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRkwFwYDVQQDExBz
-eXN0ZW06bm9kZTp0ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
-ukG4TvbrMbVklA2nLmK0T7+SygWRYebsd0vJMWkw87+zxkYY0tEo+y5ijHXucb1S
-3m4mGulmzxP1KQI/0RDuba1HhekAaOxy2TZWYhtQUxCHbrREz3b+OBbDkf2Dzp7Q
-o6J3l7fYBRCD/AnTzSCaK5LwzmH0X3TCJnrLBIf8gFrqAHsCXadNV3JQ2Iip6Gjs
-8VCqnZHS/oFhXpKiMnrB0IMpC6F21/T4Uoe+vyWoUTZQTAjZVBcIDLp3r8c6FnmF
-5YjouWafNVfbttVczNpuSt/3YxXLb2P/EQfb8QniNUXnkxSNwOpZx6QO2PZHSSBW
-cW+q+EUeFXsInl41dK5avwIDAQABoDwwOgYJKoZIhvcNAQkOMS0wKzApBgNVHREE
-IjAgggVub2RlMYILbm9kZTEubG9jYWyHBAoAAAGHBH8AAAEwDQYJKoZIhvcNAQEL
-BQADggEBAEFFAuuhgUGs7Mhg9hMdj8csuBiLHUah5bkavvi/dwH3CaHpXRAxMwRI
-0K+puuDsHn7Y7xInO2IfyYVaZ6Xr2ppT9u0Hjn9DzN3Wmd/ngTWbWsctvXVMkGw4
-Mkc4v7oq9wBbMDbsT3xKaRqWvxqAsD3NXUVGW4tIJhqZnKk3QtZ70p/q4L4/TbEV
-yOf1lhGA26sAJX4gMeTHUxPu85NedLzTg5DYDyPPvIYPKw7ww8tm2fYb67sr21WU
-p1VlUzB7qtkVJ4coGNFPwl7vu3rps5VPN7ONV9JG8+PVvjxhyQD5ZBqLVPbT7ZGI
-NKbWRRtEF/XLPoZs3kq95YCgn2oQ9ws=
------END CERTIFICATE REQUEST-----
-`
-	emptyCSR = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:test
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:node1, DNS:node1.local, IP Address:10.0.0.1, IP Address:127.0.0.1
-...
------BEGIN??
-`
-	extraAddr = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:test
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:node1, DNS:node1.local, IP Address:10.0.0.1, IP Address:127.0.0.1, IP Address:99.0.1.1
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICuTCCAaECAQAwMjEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRkwFwYDVQQDExBz
-eXN0ZW06bm9kZTp0ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
-zQPu0iSz7SbmmkpWjLV5VeBK2DAYiofOVMOgEs9rzkgnjYR0rFzaIPBFVyUkDoXb
-hDSN0P6A3yX4wg4s5uiBileQvHIgEfraOfWkmD69VE/khsi00GfmToRtttFjLosO
-GMVJwoqNFwZ3LZNLlkLlxUFCnkKely+y7LMpHQIMU7y8ZUTbxr8DAqQaFQ8HgYoF
-BIexDo6E6XutOLv5IO6HB0NvlwVkBjC4eBPDcLdO8AomHZXTZ7NBgAgrF698Mq4Q
-lD6ytYNlOc456gs+f4TJMnrElPz1Uxdw8xg3BIECzSCsd+8NeHDOGy0AZ4onDKk/
-N9nE1E+0ZBppczueXAPEzQIDAQABoEIwQAYJKoZIhvcNAQkOMTMwMTAvBgNVHREE
-KDAmggVub2RlMYILbm9kZTEubG9jYWyHBAoAAAGHBH8AAAGHBGMAAQEwDQYJKoZI
-hvcNAQELBQADggEBAE1se684AUPxTMEzNwFr7BHAvsO0BmrNDCUiRekm4NpHDna5
-7UbRLBdeUyERr6TQLjSQqsnwAgBbZh1DVyGxi4f+o6WWD4qWOovM9oMqs29MRSte
-rAyFZYysY+lOalmi/c7FTd7TpBwBMyET1ubQemG7RKnooG0wLU3ZotgRvem/A9nc
-PnziY7NNRQm7TS5u1jaOIcoUQ9qVtdhgiD9RETdI60RXtkn2+AA25kb+xdu+5sT1
-wBIbLh6TnZ4YNdW0iWVqPmRnKzgiZqQToJv4a0W/gArvA7WuafQQBt5VKol/G1Tp
-UjVeonKUB6osd0zFbSaa1jAVugOuq/TOtgqqe3I=
------END CERTIFICATE REQUEST-----
-`
-	otherName = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:foobar
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:node1, DNS:node1.local, IP Address:10.0.0.1, IP Address:127.0.0.1
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICtTCCAZ0CAQAwNDEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRswGQYDVQQDExJz
-eXN0ZW06bm9kZTpmb29iYXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
-AQDM4YGB+Ie65mWik+JqTg7YS63V5n7IgrN89YVrEeQh6Xo6+egB3cumTXlL3ReE
-eoYo+AF/TFuWx1Gblzd0rU1XmRv+zyPPmVBeMNPzOaozsfEYChI/jo1H6tkKd0hX
-l4iPOMgTCGLFdQVElFlxxuotetbiLWPF3ieCMaxPmtxqemKRPWPKm+DaZzOD3D1v
-vK/KWacuz1Jp1yZ0qD/Twt73Nw3toaDfF65ktBXVPDsNUkIj//YOag0SHMA/Fdpb
-d5cn8Vcn4Wl2tvUODxou1XWRE82Peov+ViNwhuTzDI/wUn/ODVmYO32SygvEBHwK
-heCoIKwOXKonaWWUQZw8pIgPAgMBAAGgPDA6BgkqhkiG9w0BCQ4xLTArMCkGA1Ud
-EQQiMCCCBW5vZGUxggtub2RlMS5sb2NhbIcECgAAAYcEfwAAATANBgkqhkiG9w0B
-AQsFAAOCAQEASwwkg4gJJhK68oPHaUdsMRs2MXZaJK8IddO1ikHZusmTOawBMvmy
-Lmyc6bo3svH0G9lx+CcN56pwdwkyLvmrGqgDgXleRf1joGe1I1ZS5SnFLNBc+6Rz
-XwBfEI/IIahDRnLov5E3EhguoiTtlqjtyh6hiXYS0HfuSdziCNM0f9fB0NIv7EDp
-3RIX4AWQAY/BBANop7EUixMyUyArbN9AR1FOr2zN9afFvb7lWmU4aTD3B1El3zI+
-xHhp0+EpkGHKwJN+IFchU6UXaWYaAVAYtGA2Zd1IPMr5UqhwvIYkVYYzcEZN/+Wa
-+S+DXhS+SVYtdPSJ5DqUuzjE526yZIrdcw==
------END CERTIFICATE REQUEST-----
-`
-	noNamePrefix = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = test
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:node1, DNS:node1.local, IP Address:10.0.0.1, IP Address:127.0.0.1
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICpzCCAY8CAQAwJjEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMQ0wCwYDVQQDEwR0
-ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuT/DBVT6Bn5ANmj+
-NZBOuWYUw9M6WdXyQnHuDT81qynrhKImltOG9m4M6ckCAXNRiSD8H/lT5fE6tXGO
-mDo2ZXqeGF3ZO/5mvWfW5DGD4RzIo4OaFQxDN9TxflHShIeGLITDhnc5P0DheCT0
-bfL5A000cLzudbb9Bs4P40R3W8VBTasI/q4ZjeVJYEKWVZaimg0qQDBEy0JkLhZw
-XcPmsrmKSR3YJJayAqjkQqlN1efXqIZhtabWUl2SFWrhieqtywrqeP4efIIy10hT
-EbNaCQoUMRUBHh4W6L3mi/HOXMuOXHOPMacBP1rN28irq7djvjfpnwioY8P8aAhn
-YwwqEQIDAQABoDwwOgYJKoZIhvcNAQkOMS0wKzApBgNVHREEIjAgggVub2RlMYIL
-bm9kZTEubG9jYWyHBAoAAAGHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBACd1RaL4
-b4+oeg2kjEISED2yitEjhCB3CSQdNH0+ljc/umBi3RPjy/vAf3mop1ogEMBGl4cf
-fKgbI3/tonuK8iaQz54TrfwiIUE33oA7JlCeo0t+QGzHYaDeVKx3iKXxX31aBtuV
-LylGwsjhTVkG92K4ataWtLtbyFeA7wmqQyihC1Yumhsyi1XS1mDJe0Xv2E9oAjR3
-nL49KotmSki8Ny+vLc7z5KYz7ufdzirVFhWc1KmBQO5Ze9zYuQs+di8ScjKqHhfI
-MHniHwkC/CDbtBbrSlNa7ODvqNLH0IuvxhzYqmTQKD6GIw2oCdjeSJhCsST7z5f5
-BiG1j2N6a5eFFPk=
------END CERTIFICATE REQUEST-----
-`
-	noGroup = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: CN = system:node:test
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:node1, DNS:node1.local, IP Address:10.0.0.1, IP Address:127.0.0.1
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICnDCCAYQCAQAwGzEZMBcGA1UEAxMQc3lzdGVtOm5vZGU6dGVzdDCCASIwDQYJ
-KoZIhvcNAQEBBQADggEPADCCAQoCggEBAK0S8WB/0NFUunEVepkqDCgoQcCPCLrg
-wDQnem67xbTwl9YuqX02TWXb9q9g9aDBluxOxcmpA7B3isL8kJ+GOcOjXFVUjeff
-gHg3uDz6ZjYCaD4ySfTMAMN5Vkk04NffwylQKjLAAWuuJR6/UaSaJkg3skNKelSU
-9o9+3koPaRHEMhT9B3YuKIoqsyP2r91QtNEeW5UFrfJ12Ly3t0Q6Rs7ti7SPJY3f
-3p29WBfX5RvJKmSwN6muXf1k32DP4glgwqyYqTOrKEgXdURiPOCmLA5YLhUNRvhI
-H5NZVGBFwrLOkbe17DaC3x2OISLGKj4+q67Yl6ATxWnMmkuNAYX+OgsCAwEAAaA8
-MDoGCSqGSIb3DQEJDjEtMCswKQYDVR0RBCIwIIIFbm9kZTGCC25vZGUxLmxvY2Fs
-hwQKAAABhwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQBiLcR0oSAXZ1m2QwDPDF4u
-WK3jxd8f5C9J552QsZLs8Si2kutLvzXnOgUQXjGgK9XsOyF0GBLSECivHHWCp10M
-sI2re+iuH43vMUR6hUdjrDUnPLMQYr288HwkNHM+wAQm7qFyR5YHsSYRuOjQo9BI
-DV5s0hKzo4oj6gC5KdPc+ZsQYRIENCU2+1te8ZewE0Ge/zLfrWgcs3/6wB4dwYle
-9uxPramx2SyD+/s3p59BWPG4cdTnWKF2GkrNyq8wFHYVGzn5jTW6dAi90KfYN3A4
-cD0UL3P0hRdXiCerOM6zPJvjja7jAka9UogHsG+23e96hyw/c/NmQt2dsgNjTern
------END CERTIFICATE REQUEST-----
-`
-
-	clientGood = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:panda
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICeDCCAWACAQAwMzEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRowGAYDVQQDExFz
-eXN0ZW06bm9kZTpwYW5kYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-AL7y2GsRlcv4m5gsxmxitBz5/kGRk8uzna/jyVSqNW+j0OdIYdyfkgxG8wKRdKas
-eVlQi/84DPxy0Inwu3zWVeCDYXSiTWcxcYpphubaztSOgbY1zr7oJpXvhPyjV4pZ
-rOHFX2FLYH+k6ZKLt4kgrZH0IA+Nqgs/YfUnUIY4G0Fqba6MlXRXBNKQxhsA5xLY
-NPuFiMOa9tPHan/u79/9A2/GsyJCdVhegx/+MCdejRQ0+lTWshumWFW3iMzxD/1g
-YZRvGHwB3uv51QMLdX9gEG1ek52p6dSP5SW8qoJy/KVjJyoOmRx1GQTEN1CiYtLI
-LKP4PM0yn2Cj7zSOA0HvXe8CAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQAsJa+x
-5UOOH9XlfaAVgGJDTFFtKrMT3xAOs5HDdefghmQ9Og8fybppcP6eFCoKHwFmmrAL
-XBB96wrmkbXyQf6T2pVlMVqKQisPejtLYuADTNF9hkyutdiKzfVCcnKHwJeh0Ig7
-93txMTL2nHZ8fHvY0x0JBDlMr7Sw7zLXf24GKUpQWeq79ptKTFEVUvRUZkBAi8Fd
-NXVVvO0FI4cvVK0bCZB1gj7gcH29fFfsV2PZ3gXDjWTbClq29sV3QSpuWl2UfFBB
-7y0pZ2l/2ePYhw0O45CMTPC/O/DFLFSEJ9nZXHsf4TyO2+qV4YWZir2dKGnJv7Uh
-wyDOuGAJnS9T8DLv
------END CERTIFICATE REQUEST-----
-`
-	clientExtraO = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes + O = bamboo, CN = system:node:bear
-...
------BEGIN CERTIFICATE REQUEST-----
-MIIChjCCAW4CAQAwQTEkMBMGA1UEChMMc3lzdGVtOm5vZGVzMA0GA1UEChMGYmFt
-Ym9vMRkwFwYDVQQDExBzeXN0ZW06bm9kZTpiZWFyMIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEAySEReBNyuBtXkL0ZTxoGAEYZuPLabGchMyJ2mLc0wDOB
-rvOVtlsI3otStbw+d91e7N/69oMSkuq5pL5zgabmLv6g4c2AX2oH0YPxhDRcyT0G
-D2r2c6gJN2UVhct3ZGRYt9sivfy8j68EOWJcoRm6adXWNOOlwSK7meTX2SDLvHvS
-hUpQMBqNZCtvpJJMR+Z9qTgwOWSWtqrDEa8ggimiSSgzX3S1d6L0u+d2o7Z7mzuL
-tYhEKG/VPJINUfXfmwwCKMlqbsl3phRthXr6ZrOXHIfHziy1Vd/CCAboYHLDJ/yF
-xjwWfH8QYLL8BNXVETEI810QU4dM/d901An02CWcoQIDAQABoAAwDQYJKoZIhvcN
-AQELBQADggEBAJiy9SlQWLr2gztzpWtn9iWcaZTLGZkAJI96gGTF+bZQyvnLzR3f
-2CO66bnlhB+gYlPOLyjK2JMeNM3yXs/t2blFqf8s7V3Q00iFKxYOfopaRs+WRD6z
-MMbtvej2vsQZTviIiTO6zt9w55/+ylsfURAYpcQU82jK+U8ttINIWkMrEliUoay3
-7/4Pkh+9q0HYqJeIUqpml7DEnIozaiZ4DGpgy54p17zDQDmhbP0EVBVKpzTChCV2
-dvycNksPtVm6yOlD/LaR8d9l4bOdbtuTNvMYkIk4E6k0RHklW0e6kp5ageXtm1t/
-2pqssq/xf6PHvPWnvQL3gptlRh6MMtujmbg=
------END CERTIFICATE REQUEST-----
-`
-	clientWithDNS = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:monkey
-...
-        Requested Extensions:
-            X509v3 Subject Alternative Name:
-                DNS:banana
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICnTCCAYUCAQAwNDEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRswGQYDVQQDExJz
-eXN0ZW06bm9kZTptb25rZXkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
-AQCwSXLVVdqDR2k36jh3jOzYg6WC7s31EGQrn+OmtUx0H8Rp/AHdU+dxuhU/yXqo
-14+SbOktgg3YdEYv+7ry0w31kbOOuiYGziHLaksWhJ2jWGIoZc/mzc6pW0w3mn0D
-RWbO1izCSTj2IZvuE5F1gX7KcqJ8+8vgFm10n9x/SpTZZFtSsXwEv/aW2Fi9k/OH
-51I2Lj/sRx/qM1FBexfz1kC1l+cjMbzFEWBrElSKaVBMpGJNBPXmYqfO7KocR7nq
-NlKgR/nooFJ+Ypin5oFW4vQcp+EvD8Yb9s4bUFZC8cR0THPkKlCysvWGmMM5lk9K
-ECLk+udZkXNAVBDh6jxqEP5BAgMBAAGgJDAiBgkqhkiG9w0BCQ4xFTATMBEGA1Ud
-EQQKMAiCBmJhbmFuYTANBgkqhkiG9w0BAQsFAAOCAQEApY9crYirw3ri1dbzuou9
-/DU8ZIIAVdcOKOIxFv4aVXfzKwcynnq9oihBaW64cBWdmNDm0GMWnDdDrU7iUSII
-Hc5+sGvm6xhjPOOM3zoELnKaSc3BOk3KsxtJKo1HVZdX5GWULTkjgzC+LYuHmUzL
-p+V+Msa7zMo3IIFp1Afq2bGeoxhsAAGyaHHRwI0xg9Lu8Owl4KL8Avxs6AUjktMN
-flHQDhama36J++VAP7i+WpJ0Eh+sncxptzPrs+kbA5qD5ZA+Qybgiabahuoey27z
-3xFSjy8rgvH9vIMv8DOaCnKrd6KAO7fz5o8wB9TfOOX1eUTgy3wwHAPRAM2iSKCz
-rQ==
------END CERTIFICATE REQUEST-----
-`
-	clientWrongCN = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:notnode:zebra
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICezCCAWMCAQAwNjEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMR0wGwYDVQQDExRz
-eXN0ZW06bm90bm9kZTp6ZWJyYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBANw41UjnXcvF3rTOSpnYxkMNquMApc2D33fwVyVtn8SosILT+K0LJN3iISFr
-4jvV7KbaFVhL+w98jFa+lHgz0n0B9QZMuzhxgQfax8KhY6Jx86d95IpRwIaS36FB
-5oTHRZZPRCRZyAMonBqv1WvqwCPXqJj1x1q5b2ZePYb8NZYXA+8h46QF6zhy1CgU
-Uyhh0314dGSp+EAZ1+mCA1pZHn7jm7GxEBgFrj+vmdqaqMGw6ePkyoXf4CwpS1Yk
-hWF2pvC8aH1pxXJwgk5TXRgLhGtmxcM/yKy2HKuUs8ZVrfEZ8ubdEY9ZUzJRaVxn
-Imz1kqoVqk8H8jS9R6xTAdpTm4MCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQCg
-keFlA6YlnX8K6zFg1MrypGmx2/U2EpGIi3LjXUg3RTxtt47nemJyCHqNOVRXUVaA
-w/F2U11jFn0Vzd4Dsfa6+Zmhju/8ZiyRcw22lTqj1OHPwaKa5gJpN1TYbajhKs/l
-EMD445dySwxCms2mu/wY8dEhwJDWWZXl7cYD8mS8wt3XueciOjq+P2vqqH7t8RPl
-QaeQ34WHQsPopbdb49Wwpz+jH/3vpe/GYz8lnDRoxUKpLS8vrYVog8cHO4GP6upR
-xdZGDp5UH/komvTyr+PrGCpB6SQnGp01XSjLKBwSYnqSp9JYTG+xKN2LYS65EYrw
-mG57VlB8JU+F3mZOeMSC
------END CERTIFICATE REQUEST-----
-`
-	clientEmptyName = `
-Certificate Request:
-    Data:
-        Version: 1 (0x0)
-        Subject: O = system:nodes, CN = system:node:
-...
------BEGIN CERTIFICATE REQUEST-----
-MIICczCCAVsCAQAwLjEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRUwEwYDVQQDEwxz
-eXN0ZW06bm9kZTowggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/m0SP
-zooyqB2raVHz183M2oUklhQCRP3DVqBFtt0kC5BB6zzfWdnk5clsu3yyA/vGNFo3
-f+jNCrtP9/LVjXrbfiQrWfoyMW10gBOsSO7ovSuMhwPd7/8vEoUs+eOnYqp2khZ5
-5KvJLMa7e59WZvzsqBWMMRWp9sCVXFpDwHbq8bAWoDZYhxyLR8f3d8sYH6oncj9m
-lbn3NAPakTvSnSJwPepSby3bUykgCP7SuU7P4PrlAXf55kTX/+DV5ZG3TO/cdVhl
-7F1rwQ6vetzp1bb36sbWtYv0oDMw9+tNpmiUfDr/9bOf/6zNTUij6ZRylYleo1I1
-OKdI21OBRFAhhyVvAgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAW5cOsaSYnURz
-wnMRVpr7B821+DZu1G8Mv1lUzEvU+ZaVIaIL6Dv0BfDb9QLOYHzfceCYzJmavSOl
-SdZLoLkL1SYUp77tGDcbwWQyngWY5G7upZudBMEYOHvG/4YnNPb+5BkIgsREJl/+
-jVK2u+yuAkzkDdODM2NwRP9TGhPCbcqFeE2ozdJzluIGYafsQFPFr7kb8liiOV2O
-u1xKRHq7Bb54+3sRt1PsmuYhIl4l1Sh1epKIhUGzBxyzJUAKsbsPk6s64euMhCxz
-VoJUoVggIY3WxIVV+rpqlC7ThIgdYkq7fZeAeYAnbwB8eM208w5NUgxYTsZN7VDo
-rj/Dkdwyag==
------END CERTIFICATE REQUEST-----
 `
 )
 
@@ -353,6 +82,18 @@ func init() {
 	rootCertGood = string(rootCert)
 	serverCertGood = string(serverCert)
 	serverKeyGood = string(serverKey)
+
+	goodCSR = createCR("system:node:test", nil, nil, nil)
+	extraAddr = createCR("system:node:test", nil, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.0.1"), net.ParseIP("99.0.1.1")}, nil)
+	otherName = createCR("system:node:foobar", nil, nil, nil)
+	noNamePrefix = createCR("test", nil, nil, nil)
+	noGroup = createCR("system:node:test", []string{}, nil, nil)
+	clientGood = createCR("system:node:panda", nil, []net.IP{}, []string{})
+	clientExtraO = createCR("system:node:bear", []string{"bamboo", "system:nodes"}, []net.IP{}, []string{})
+	clientWithDNS = createCR("system:node:monkey", nil, []net.IP{}, []string{"banana"})
+	clientWrongCN = createCR("system:notnode:zebra", nil, []net.IP{}, []string{})
+	clientEmptyName = createCR("system:node:", nil, []net.IP{}, []string{})
+	emptyCSR = "-----BEGIN??\n"
 }
 
 func generateCertKeyPair(duration time.Duration, parentCertPEM, parentKeyPEM []byte, commonName string, otherNames ...string) ([]byte, []byte, error) {
@@ -424,7 +165,7 @@ func generateCertKeyPair(duration time.Duration, parentCertPEM, parentKeyPEM []b
 	return certOut.Bytes(), keyOut.Bytes(), nil
 }
 
-func createCsr(commonName string, organizations []string, ipAddressess []net.IP, dnsNames []string) string {
+func createCR(commonName string, organizations []string, ipAddressess []net.IP, dnsNames []string) string {
 	defaultOrganizations := []string{"system:nodes"}
 	defaultIPAdresses := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.0.1")}
 	defaultDnsNames := []string{"node1", "node1.local"}
@@ -458,89 +199,6 @@ func createCsr(commonName string, organizations []string, ipAddressess []net.IP,
 	csrBytes, _ := x509.CreateCertificateRequest(rand.Reader, &template, keyBytes)
 	pem.Encode(csrOut, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
 	return csrOut.String()
-}
-
-/// Temporary test for ensure that createCsr function creates csrs with same attributes as constants have in this file
-func Test_csrGeneration(t *testing.T) {
-
-	type csrTestCase struct {
-		subjOkToDiff        bool
-		name                string
-		encodedGeneratedCsr string
-		encodedConstantCsr  string
-	}
-
-	generatedGoodCsr := createCsr("system:node:test", nil, nil, nil)
-	generatedExtraAddr := createCsr("system:node:test", nil, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.0.1"), net.ParseIP("99.0.1.1")}, nil)
-	generatedOtherName := createCsr("system:node:foobar", nil, nil, nil)
-	generatedNoNamePrefix := createCsr("test", nil, nil, nil)
-	generatedNoGroup := createCsr("system:node:test", []string{}, nil, nil)
-	generatedClientGood := createCsr("system:node:panda", nil, []net.IP{}, []string{})
-	generatedClentExtraO := createCsr("system:node:bear", []string{"bamboo", "system:nodes"}, []net.IP{}, []string{})
-	generatedClientWithDNS := createCsr("system:node:monkey", nil, []net.IP{}, []string{"banana"})
-	generatedClientWrongCN := createCsr("system:notnode:zebra", nil, []net.IP{}, []string{})
-	generatedClientEmptyName := createCsr("system:node:", nil, []net.IP{}, []string{})
-
-	tcs := []csrTestCase{
-		{false, "goodCsr", generatedGoodCsr, goodCSR},
-		{false, "extraAddr", generatedExtraAddr, extraAddr},
-		{false, "otherName", generatedOtherName, otherName},
-		{false, "noNamePrefix", generatedNoNamePrefix, noNamePrefix},
-		{false, "noGroup", generatedNoGroup, noGroup},
-		{false, "clientGood", generatedClientGood, clientGood},
-		{true, "clientExtraO", generatedClentExtraO, clientExtraO},
-		{false, "clientWithDNS", generatedClientWithDNS, clientWithDNS},
-		{false, "clientWrongCN", generatedClientWrongCN, clientWrongCN},
-		{false, "clientEmptyName", generatedClientEmptyName, clientEmptyName},
-	}
-
-	_parseCSR := func(encoded string) *x509.CertificateRequest {
-		block, _ := pem.Decode([]byte(encoded))
-		req, err := x509.ParseCertificateRequest(block.Bytes)
-		if err != nil {
-			t.Error(err)
-		}
-		return req
-	}
-
-	allTrue := func(toCheck ...bool) bool {
-		for _, v := range toCheck {
-			if !v {
-				return false
-			}
-		}
-		return true
-	}
-
-	sortIps := func(ips []net.IP) []net.IP {
-		sort.Slice(ips, func(i, j int) bool {
-			return bytes.Compare(ips[i], ips[j]) < 0
-		})
-		return ips
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			okToDiff := tc.subjOkToDiff
-			name := tc.name
-			generated := tc.encodedGeneratedCsr
-			constant := tc.encodedConstantCsr
-			generatedRequest := _parseCSR(generated)
-			constantRequest := _parseCSR(constant)
-
-			subjectOk := reflect.DeepEqual(generatedRequest.Subject, constantRequest.Subject)
-			ipsOk := reflect.DeepEqual(sortIps(generatedRequest.IPAddresses), sortIps(constantRequest.IPAddresses))
-			dnsOk := reflect.DeepEqual(generatedRequest.DNSNames, constantRequest.DNSNames)
-
-			if !allTrue(subjectOk, ipsOk, dnsOk) {
-				if !okToDiff {
-					t.Errorf("CSR %v ATTRIBTUES DOES NOT MATCH. subjectOk: %v, ipsOk: %v, dnsOk: %v", name, subjectOk, ipsOk, dnsOk)
-				}
-				fmt.Printf("%v Csrs subj is ok to diff, diff:\n", name)
-				fmt.Println(diff.ObjectDiff(generatedRequest.Subject, constantRequest.Subject))
-			}
-		})
-	}
 }
 
 func Test_authorizeCSR(t *testing.T) {


### PR DESCRIPTION
This pr contains:
- Moving machines creation to function in Test_authorizeCSR test suite.

 - CRs generation was moved to function, instead of having constants in test file.
For ensure that generated CRs attrs are equal to constant ones this [commit](https://github.com/openshift/cluster-machine-approver/pull/155/commits/eaec2db32f83d6812a2d09cdf5bca98352473b5e) contained test. 
Run results might be checked here: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-machine-approver/155/pull-ci-openshift-cluster-machine-approver-master-unit/1488863004706476032/build-log.txt