### PR TITLE
Allow to define several API groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 	github.com/openshift/library-go v0.0.0-20211217094823-cbb293285c81
 	github.com/prometheus/client_golang v1.11.0
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
@@ -44,7 +45,6 @@ require (
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -68,6 +68,7 @@ spec:
         - "--leader-elect-renew-deadline=107s"
         - "--leader-elect-retry-period=26s"
         - "--leader-elect-resource-namespace=openshift-cluster-machine-approver"
+        - "--api-group-version=machine.openshift.io/v1beta1"
         resources:
           requests:
             memory: 50Mi

--- a/pkg/machinehandler/machinehandler_test.go
+++ b/pkg/machinehandler/machinehandler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -155,13 +156,12 @@ func Test_authorizeCSR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := MachineHandler{
-				APIGroup:  tt.args.apiGroup,
 				Client:    tt.args.client,
 				Config:    tt.args.config,
 				Ctx:       tt.args.ctx,
 				Namespace: tt.args.namespace,
 			}
-			machines, err := handler.ListMachines()
+			machines, err := handler.ListMachines(schema.GroupVersion{Group: tt.args.apiGroup})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("unexpected error returned. wantErr: %t. err: %v.", tt.wantErr, err)
 			}


### PR DESCRIPTION
Currently approver can work with just one API group, which is defined by --apigroup option. This patch allows to set several API groups, so that the component is able to approve certificates for machines created by various APIs.

For OpenShift it means that we don't have to deploy 2 approvers: one for MAPI and another for CAPI. Instead we can use one instance that manages them all.

Also, using of api-group-version instead of just api-group allows us to define what API version we'd like to use. It's important because In openshift/machine-api-operator#992, we are introducing a new CRD which is in the machine.openshift.io/v1 group. This means that the server preferred version of the API is now v1 and not v1beta1. Because Machines don't yet exist in the v1 group, this means the CMA is currently broken on that PR.

```txt
E0223 11:12:04.550754       1 controller.go:134] csr-mwwzt: Failed to list machines: no matches for kind "Machine" in version "machine.openshift.io/v1"
```

If we were to merge openshift/machine-api-operator#992 we would break the CMA across openshift. To mitigate this, we must allow the version to be set manually as a part of api-group-version, and only rely on discovery when the preferred version is not set there.

Deprecations:
`--apigroup` is deprecated in favor of `--apigroupversion` option

New options:
`--api-group-version` allows to specify both API group and version. This option can be given multiple times.