### PR TITLE
Add techpreview manifests for CAPI machines

### DIFF
--- a/manifests/01-rbac-capi.yaml
+++ b/manifests/01-rbac-capi.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:controller:machine-approver-capi
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+rules:
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:controller:machine-approver-capi
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:controller:machine-approver-capi
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-machine-approver
+  name: machine-approver-sa

--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-cluster-machine-approver
+  name: machine-approver-capi
+  labels:
+    app: machine-approver-capi
+    machine-approver-capi: "true"
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: machine-approver-capi
+  template:
+    metadata:
+      name: machine-approver-capi
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: machine-approver-capi
+    spec:
+      hostNetwork: true
+      serviceAccountName: machine-approver-sa
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:9192
+        - --upstream=http://127.0.0.1:9191/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --logtostderr=true
+        - --v=3
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.2.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9192
+          name: https
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: auth-proxy-config
+        - mountPath: /etc/tls/private
+          name: machine-approver-tls
+      - name: machine-approver-controller
+        image: docker.io/openshift/origin-cluster-machine-approver:v4.0
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/machine-approver"]
+        args:
+        - "--config=/var/run/configmaps/config/config.yaml"
+        - "-v=2"
+        - "--logtostderr"
+        - "--leader-elect=true"
+        - "--leader-elect-lease-duration=137s"
+        - "--leader-elect-renew-deadline=107s"
+        - "--leader-elect-retry-period=26s"
+        - "--leader-elect-resource-namespace=openshift-cluster-machine-approver"
+        - "--leader-elect-resource-name=capi-cluster-machine-approver-leader"
+        - "--api-group-version=cluster.x-k8s.io/v1beta1"
+        - "--disable-status-controller=true"
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
+        - name: METRICS_PORT
+          value: "9191"
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - configMap:
+          name: kube-rbac-proxy
+        name: auth-proxy-config
+      - name: machine-approver-tls
+        secret:
+          secretName: machine-approver-tls
+      - name: config
+        configMap:
+          defaultMode: 440
+          name: machine-approver-config
+          optional: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: node-role.kubernetes.io/master  # Just tolerate NoSchedule taint on master node. If there are other conditions like disk-pressure etc, let's not schedule the control-plane pods onto that node.
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 # Evict pods within 2 mins.
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 # Evict pods within 2 mins.


### PR DESCRIPTION
Add techpreview manifests for CAPI machines, this is the easiest way to have CMA work with CAPI machines in techpreview phase.