### PR TITLE
Set default container for log retrieval

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    kubectl.kubernetes.io/default-container: machine-approver-controller
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
This allows the command `oc -n openshift-cluster-machine-approver logs deploy/machine-approver` to run and grab the `machine-approver-controller` logs by default (the `kube-rbac-proxy` container logs are usually less interesting)