### PR TITLE
Support Azure ephemeral OS Disk machine redeploys

### DIFF
--- a/pkg/machinehandler/machinehandler.go
+++ b/pkg/machinehandler/machinehandler.go
@@ -155,3 +155,13 @@ func FindMatchingMachineFromNodeRef(machines []Machine, nodeName string) (*Machi
 	}
 	return nil, fmt.Errorf("matching machine not found")
 }
+
+// Check whether a machine is an Azure Ephemeral OS Disk VM
+func IsMachineAzureEphemeralOsDiskNode(machines []Machine, nodeName string) bool {
+	for _, machine := range machines {
+		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == nodeName {
+			return machine.Spec.ProviderSpec.Value.OsDisk.OsDiskSettings.EphemeralStorageLocation == "Local"
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Creating an Azure ephemeral OS disk node works as expected in OCP 4.10, however when a machine is redeployed it will never rejoin the cluster due to the node already existing, as well as the nodeRef and potentially failing the creation time test, depending on how soon the node is redeployed after creation.

This is due to the fact that, when an ephemeral OS disk node is redeployed, the OS is re-provisioned during the process. This limitation is listed in the [Azure ephemeral OS disk docs](https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks).

Due to the fact that we use redeploy actions to support clusters in ARO extensively, we are currently blocked from offering this feature on the platform until this issue is mitigated.

The approach taken in this PR does result in a circumvention of some validations, but keen to iterate to get the concept merged.