### PR TITLE
ignore case when checking csr hostnames

### DIFF
--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -373,9 +373,9 @@ func authorizeServingCertWithMachine(machines []machinehandlerpkg.Machine, req *
 		var attemptedAddresses []string
 		var foundSan bool
 		for _, addr := range targetMachine.Status.Addresses {
-			switch corev1.NodeAddressType(addr.Type) {
+			switch addr.Type {
 			case corev1.NodeInternalDNS, corev1.NodeExternalDNS, corev1.NodeHostName:
-				if san == addr.Address {
+				if strings.EqualFold(san, addr.Address) {
 					foundSan = true
 					break
 				} else {


### PR DESCRIPTION
Related to OSD-12989.  The machine approver doesn't recognize hostnames that use capital letters as valid even though DNS is case-insensitive.  This change will allow the machine approver to properly recognize those hostnames.