### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12

### DIFF
--- a/manifests/01-rbac-capi.yaml
+++ b/manifests/01-rbac-capi.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 rules:
 - apiGroups:
   - cluster.x-k8s.io
@@ -27,7 +27,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -10,7 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
This was added in https://github.com/openshift/cluster-version-operator/pull/821 to allow more featuresets and allow for a future migration to include actual gates. Because usage of this manifest would prevent upgrades, there are not upgrade concerns for this change.