### PR TITLE
Patch CSR name onto Machine annotations

### DIFF
--- a/manifests/01-rbac.yaml
+++ b/manifests/01-rbac.yaml
@@ -135,6 +135,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -60,7 +60,7 @@ func validateCSRContents(req *certificatesv1.CertificateSigningRequest, csr *x50
 		return "", nil
 	}
 
-	nodeAsking := strings.TrimPrefix(req.Spec.Username, nodeUserPrefix)
+	nodeAsking := getNodeName(req)
 	if len(nodeAsking) == 0 {
 		klog.Infof("%v: CSR does not appear to be a node serving cert", req.Name)
 		return "", nil
@@ -707,4 +707,9 @@ func certSANs(cert *x509.Certificate) []string {
 	}
 
 	return sans
+}
+
+// getNodeName trims the CSRs Spec.Username to get the expected node name.
+func getNodeName(csr *certificatesv1.CertificateSigningRequest) string {
+	return strings.TrimPrefix(csr.Spec.Username, nodeUserPrefix)
 }


### PR DESCRIPTION
Sometimes it may happen that it takes Machine controller some time to reconcile the Machine and update object with current state while cloud provider already did so. In such situations automatic approval of the CSR may fail because Machine object Status is not up to date.

In order to force reconciliation of the Machine object this commit implements adding an annotation with the CSR name to the Machine object when CSR verification fails.