### PR TITLE
OCPBUGS-11225: Update node client allowed usages

### DIFF
--- a/pkg/controller/node_client.go
+++ b/pkg/controller/node_client.go
@@ -36,7 +36,7 @@ var kubeletClientUsagesLegacy = []certificatesv1.KeyUsage{
 }
 
 var kubeletClientUsages = []certificatesv1.KeyUsage{
-	certificatesv1.UsageKeyEncipherment,
+	certificatesv1.UsageDigitalSignature,
 	certificatesv1.UsageClientAuth,
 }
 


### PR DESCRIPTION
In 1.27, we expect to use digital signature and client auth, not key encipherment, so need to update this