### PR TITLE
Go 1.20 bump with fixed unit tests

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.14
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-machine-approver
 COPY . .
 RUN make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-machine-approver
 
-go 1.19
+go 1.20
 
 require (
 	github.com/mitchellh/mapstructure v1.5.0

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -1863,7 +1863,7 @@ func TestGetServingCert(t *testing.T) {
 			nodeName:  "test",
 			node:      defaultNode,
 			rootCerts: []*x509.Certificate{parseCert(t, differentCert)},
-			wantErr:   "x509: certificate signed by unknown authority",
+			wantErr:   "tls: failed to verify certificate: x509: certificate signed by unknown authority",
 		},
 		{
 			name:      "node not found",


### PR DESCRIPTION
Go 1.20 adds additional wrapping to the unknown authority error. This fails our test.

Fixes the test and bumps go.mod go version, because the test only works for go 1.20 and above now.