### PR TITLE
OCPBUGS-17090: Set logger for controller runtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,9 @@ func main() {
 
 	flagSet := flag.NewFlagSet("cluster-machine-approver", flag.ExitOnError)
 
+	// Set logger for controller-runtime
+	control.SetLogger(klog.NewKlogr())
+
 	klog.InitFlags(nil)
 	flagSet.AddGoFlagSet(goflag.CommandLine)
 

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -1863,7 +1863,7 @@ func TestGetServingCert(t *testing.T) {
 			nodeName:  "test",
 			node:      defaultNode,
 			rootCerts: []*x509.Certificate{parseCert(t, differentCert)},
-			wantErr:   "x509: certificate signed by unknown authority",
+			wantErr:   "tls: failed to verify certificate: x509: certificate signed by unknown authority",
 		},
 		{
 			name:      "node not found",


### PR DESCRIPTION
We were getting error messages from controller-runtime that no logger is set for it. This patch fixes that.