### PR TITLE
[OCPBUGS-21594] Add a metric of pending CSRs that will be handle by machine approver.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -178,6 +178,8 @@ func reconcileLimits(csrName string, machines []machinehandlerpkg.Machine, nodes
 	atomic.StoreUint32(&MaxPendingCSRs, uint32(maxPending))
 	pending := recentlyPendingCSRs(csrs.Items)
 	atomic.StoreUint32(&PendingCSRs, uint32(pending))
+	pendingNodeCertificates := recentlyPendingNodeCSRs(csrs.Items)
+	atomic.StoreUint32(&PendingNodeCSRs, uint32(pendingNodeCertificates))
 	if pending > maxPending {
 		klog.Errorf("%v: Pending CSRs: %d; Max pending allowed: %d. Difference between pending CSRs and machines > %v. Ignoring all CSRs as too many recent pending CSRs seen", csrName, pending, maxPending, maxDiffBetweenPendingCSRsAndMachinesCount)
 		return true

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,6 +15,8 @@ const DefaultMetricsPort = ":9191"
 var (
 	// CurrentPendingCSRCountDesc is a metric to report count of the pending csr in the cluster
 	CurrentPendingCSRCountDesc = prometheus.NewDesc("mapi_current_pending_csr", "Count of pending CSRs at the cluster level", nil, nil)
+	// CurrentPendingCSRCountDesc is a metric to report count of the pending csr in the cluster
+	CurrentPendingNodeCSRCountDesc = prometheus.NewDesc("mapi_current_pending_node_csr", "Count of pending node CSRs at the cluster level", nil, nil)
 	// MaxPendingCSRDesc is a metric to report threshold value of the pending csr beyond which csr will be ignored
 	MaxPendingCSRDesc = prometheus.NewDesc("mapi_max_pending_csr", "Threshold value of the pending CSRs beyond which any new CSR requests will be ignored ", nil, nil)
 )
@@ -40,6 +42,7 @@ func (mc MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect implements the prometheus.Collector interface.
 func (mc MetricsCollector) collectMetrics(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(CurrentPendingCSRCountDesc, prometheus.GaugeValue, float64(atomic.LoadUint32(&controller.PendingCSRs)))
+	ch <- prometheus.MustNewConstMetric(CurrentPendingNodeCSRCountDesc, prometheus.GaugeValue, float64(atomic.LoadUint32(&controller.PendingNodeCSRs)))
 	ch <- prometheus.MustNewConstMetric(MaxPendingCSRDesc, prometheus.GaugeValue, float64(atomic.LoadUint32(&controller.MaxPendingCSRs)))
 	klog.V(4).Infof("collectMetrics exit")
 }


### PR DESCRIPTION
Instead of just storing all pending CSRs, add a new metric that only holds the number of pending CSRs that are node CSRs.

I didn't want to overwrite the old metric, as that would disconnect the metric name from what's actually stored in the metric.