### PR TITLE
OCPCLOUD-2277: Ensure Cluster Machine Approver metrics are only available via HTTPS

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -80,8 +80,6 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
-        - name: METRICS_PORT
-          value: "9191"
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - configMap:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 // defaultMetricsPort is the default port to expose metrics.
-const DefaultMetricsPort = ":9191"
+const DefaultMetricsPort = "127.0.0.1:9191"
 
 var (
 	// CurrentPendingCSRCountDesc is a metric to report count of pending node CSRs in the cluster


### PR DESCRIPTION
This is a draft PR to spin up a cluster to test my changes for [OCPCLOUD-2277](https://issues.redhat.com//browse/OCPCLOUD-2277) - will create a more useful description once I can confirm this change works as expected.