### PR TITLE
Revert #211 "OCPCLOUD-2277: Ensure Cluster Machine Approver metrics are only available via HTTPS"

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -80,6 +80,8 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
+        - name: METRICS_PORT
+          value: "9191"
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - configMap:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 // defaultMetricsPort is the default port to expose metrics.
-const DefaultMetricsPort = "127.0.0.1:9191"
+const DefaultMetricsPort = ":9191"
 
 var (
 	// CurrentPendingCSRCountDesc is a metric to report count of pending node CSRs in the cluster


### PR DESCRIPTION
Reverts #211 ; tracked by OCPBUGS-23737

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Hypershift e2e failed in 4.15.0-0.ci-2023-11-22-141748 - Hypershift team acknowledges they need to remove the probe.  Staging the revert for now in case they don't get it worked out quickly.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Need to consult with hypershift team to validate the dependent probes have been removed
```

CC: @racheljpg

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
