### PR TITLE
[release-4.12] OCPBUGS-23486: Filter non node CSRs in metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export GOPROXY
 BUILD_IMAGE ?= registry.ci.openshift.org/openshift/release:golang-1.18
 
 
-NO_DOCKER ?= 0
+NO_DOCKER ?= 1
 
 ifeq ($(shell command -v podman > /dev/null 2>&1 ; echo $$? ), 0)
 	ENGINE=podman

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -177,7 +177,7 @@ func (m *CertificateApprover) Reconcile(ctx context.Context, req ctrl.Request) (
 func reconcileLimits(csrName string, machines []machinehandlerpkg.Machine, nodes *corev1.NodeList, csrs *certificatesv1.CertificateSigningRequestList) bool {
 	maxPending := getMaxPending(machines, nodes)
 	atomic.StoreUint32(&MaxPendingCSRs, uint32(maxPending))
-	pending := recentlyPendingCSRs(csrs.Items)
+	pending := recentlyPendingNodeCSRs(csrs.Items)
 	atomic.StoreUint32(&PendingCSRs, uint32(pending))
 	if pending > maxPending {
 		klog.Errorf("%v: Pending CSRs: %d; Max pending allowed: %d. Difference between pending CSRs and machines > %v. Ignoring all CSRs as too many recent pending CSRs seen", csrName, pending, maxPending, maxDiffBetweenPendingCSRsAndMachinesCount)

--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -490,7 +490,7 @@ func isApprovedByCMA(csr certificatesv1.CertificateSigningRequest) bool {
 	return false
 }
 
-func recentlyPendingCSRs(csrs []certificatesv1.CertificateSigningRequest) int {
+func recentlyPendingNodeCSRs(csrs []certificatesv1.CertificateSigningRequest) int {
 	// assumes we are scheduled on the master meaning our clock is the same
 	currentTime := now()
 	start := currentTime.Add(-maxPendingDelta)
@@ -504,12 +504,16 @@ func recentlyPendingCSRs(csrs []certificatesv1.CertificateSigningRequest) int {
 			continue
 		}
 
-		if !isApproved(csr) {
+		if (isReqFromNodeBootstrapper(&csr) || isRequestFromNodeUser(csr)) && !isApproved(csr) {
 			pending++
 		}
 	}
 
 	return pending
+}
+
+func isRequestFromNodeUser(csr certificatesv1.CertificateSigningRequest) bool {
+	return strings.HasPrefix(csr.Spec.Username, nodeUserPrefix)
 }
 
 // getServingCert fetches the node by the given name and attempts to connect to

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -13,10 +13,10 @@ import (
 const DefaultMetricsPort = ":9191"
 
 var (
-	// CurrentPendingCSRCountDesc is a metric to report count of the pending csr in the cluster
-	CurrentPendingCSRCountDesc = prometheus.NewDesc("mapi_current_pending_csr", "Count of pending CSRs at the cluster level", nil, nil)
-	// MaxPendingCSRDesc is a metric to report threshold value of the pending csr beyond which csr will be ignored
-	MaxPendingCSRDesc = prometheus.NewDesc("mapi_max_pending_csr", "Threshold value of the pending CSRs beyond which any new CSR requests will be ignored ", nil, nil)
+	// CurrentPendingCSRCountDesc is a metric to report count of pending node CSRs in the cluster
+	CurrentPendingCSRCountDesc = prometheus.NewDesc("mapi_current_pending_csr", "Count of recently pending node CSRs at the cluster level", nil, nil)
+	// MaxPendingCSRDesc is a metric to report threshold value of the pending node CSRs beyond which all CSR will be ignored by machine approver
+	MaxPendingCSRDesc = prometheus.NewDesc("mapi_max_pending_csr", "Threshold value of the pending node CSRs beyond which all CSR will be ignored by machine approver", nil, nil)
 )
 
 func init() {


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/cluster-machine-approver/pull/210 with `NO_DOCKER=1` cherry-pick.