### PR TITLE
OCPBUGS-23544: Increase concurrent reconciles to 10

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func main() {
 	var machineNamespace string
 	var workloadKubeConfigPath string
 	var disableStatusController bool
+	var maxConcurrentReconciles int
+
 	var leaderElect bool
 	var leaderElectLeaseDuration time.Duration
 	var leaderElectRenewDeadline time.Duration
@@ -76,6 +78,7 @@ func main() {
 	flagSet.StringVar(&machineNamespace, "machine-namespace", "", "restrict machine operations to a specific namespace, if not set, all machines will be observed in approval decisions")
 	flagSet.StringVar(&workloadKubeConfigPath, "workload-cluster-kubeconfig", "", "workload kubeconfig path")
 	flagSet.BoolVar(&disableStatusController, "disable-status-controller", false, "disable status controller that will update the machine-approver clusteroperator status")
+	flagSet.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "maximum number concurrent reconciles for the CSR approving controller")
 
 	flagSet.BoolVar(&leaderElect, "leader-elect", true, "use leader election when starting the manager.")
 	flagSet.DurationVar(&leaderElectLeaseDuration, "leader-elect-lease-duration", 137*time.Second, "the duration that non-leader candidates will wait to force acquire leadership.")
@@ -211,7 +214,9 @@ func main() {
 		NodeRestCfg:      workloadConfig,
 		Config:           controller.LoadConfig(cliConfig),
 		APIGroupVersions: parsedAPIGroupVersions,
-	}).SetupWithManager(mgr, ctrl.Options{}); err != nil {
+	}).SetupWithManager(mgr, ctrl.Options{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+	}); err != nil {
 		klog.Fatalf("unable to create CSR controller: %v", err)
 	}
 

--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -71,6 +71,7 @@ spec:
         - "--leader-elect-resource-name=capi-cluster-machine-approver-leader"
         - "--api-group-version=cluster.x-k8s.io/v1beta1"
         - "--disable-status-controller=true"
+        - "--max-concurrent-reconciles=10"
         resources:
           requests:
             memory: 50Mi

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -70,6 +70,7 @@ spec:
         - "--leader-elect-retry-period=26s"
         - "--leader-elect-resource-namespace=openshift-cluster-machine-approver"
         - "--api-group-version=machine.openshift.io/v1beta1"
+        - "--max-concurrent-reconciles=10"
         resources:
           requests:
             memory: 50Mi

--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -510,7 +510,7 @@ func recentlyPendingNodeCSRs(csrs []certificatesv1.CertificateSigningRequest) in
 			continue
 		}
 
-		if (isReqFromNodeBootstrapper(&csr) || isRequestFromNodeUser(csr)) && !isApproved(csr) {
+		if (isReqFromNodeBootstrapper(&csr) || isRequestFromNodeUser(csr) && !isRequestFromMultus(csr)) && !isApproved(csr) {
 			pending++
 		}
 	}
@@ -520,6 +520,16 @@ func recentlyPendingNodeCSRs(csrs []certificatesv1.CertificateSigningRequest) in
 
 func isRequestFromNodeUser(csr certificatesv1.CertificateSigningRequest) bool {
 	return strings.HasPrefix(csr.Spec.Username, nodeUserPrefix)
+}
+
+func isRequestFromMultus(csr certificatesv1.CertificateSigningRequest) bool {
+	parsedCSR, err := parseCSR(&csr)
+	if err != nil {
+		klog.Errorf("%v: Failed to parse csr: %v", csr.Name, err)
+		return false
+	}
+
+	return strings.HasPrefix(parsedCSR.Subject.CommonName, "system:multus:")
 }
 
 // getServingCert fetches the node by the given name and attempts to connect to


### PR DESCRIPTION
Approving CSRs should not need to be in sequence, we should be able to process in parallel. Kubelet will create CSRs when it starts and these should be approved in a timely manner. On large scale events, we are slow to process the CSRs and this is causing kubelet to create duplicate CSRs.

Creating duplicates leads to us exhausting our limit which stops approval altogether.

The only time where we may have an issue is if 2 concurrent reconciles approve client CSRs for the same node at the same time, this today has a check in place such that we don't approve client CSRs when nodes already exist. In theory, this should never happen if we are approving the client CSRs promptly anyway.

I also noticed while working on this, that we are accounting for Multus CSRs when calculating the pending number of CSRs. As these CSRs are networking related, approved by a different controller and not related to our intended operation here, I'm excluding them from being considered as part of the pending CSR count.