### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -44,9 +44,8 @@ spec:
         - containerPort: 9192
           name: https
           protocol: TCP
-        resources: {}
         terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
             memory: 20Mi


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.