### PR TITLE
OCPBUGS-36871: Client internal DNS checks should be case insensitive

### DIFF
--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -832,6 +832,33 @@ func Test_authorizeCSR(t *testing.T) {
 			authorize: true,
 		},
 		{
+			name: "client good with upper case DNS",
+			args: args{
+				machines: []machinehandlerpkg.Machine{
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "TIGERS"}),
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "PANDA"}),
+				},
+				req: &certificatesv1.CertificateSigningRequest{
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						Usages: []certificatesv1.KeyUsage{
+							certificatesv1.UsageKeyEncipherment,
+							certificatesv1.UsageDigitalSignature,
+							certificatesv1.UsageClientAuth,
+						},
+						Username: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper",
+						Groups: []string{
+							"system:authenticated",
+							"system:serviceaccounts:openshift-machine-config-operator",
+							"system:serviceaccounts",
+						},
+					},
+				},
+				csr: clientGood,
+			},
+			wantErr:   "",
+			authorize: true,
+		},
+		{
 			name: "client extra O",
 			args: args{
 				machines: []machinehandlerpkg.Machine{

--- a/pkg/machinehandler/machinehandler.go
+++ b/pkg/machinehandler/machinehandler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -160,7 +161,7 @@ func isMachineCRDPresent(cfg *rest.Config, groupVersion schema.GroupVersion) (bo
 func FindMatchingMachineFromInternalDNS(machines []Machine, nodeName string) (*Machine, error) {
 	for _, machine := range machines {
 		for _, address := range machine.Status.Addresses {
-			if corev1.NodeAddressType(address.Type) == corev1.NodeInternalDNS && address.Address == nodeName {
+			if corev1.NodeAddressType(address.Type) == corev1.NodeInternalDNS && strings.EqualFold(address.Address, nodeName) {
 				return &machine, nil
 			}
 		}


### PR DESCRIPTION
DNS names are case insensitive. Kubelet automatically lower cases names, but, our actuators may not (especially on AWS). In this case, the client certificates cannot be approved, because we currently look for an exact match between the node name and the DNS name.