### PR TITLE
OCPBUGS-45306: Client internal DNS checks should ignore trailing dot

### DIFF
--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -859,6 +859,33 @@ func Test_authorizeCSR(t *testing.T) {
 			authorize: true,
 		},
 		{
+			name: "client good with trailing dot in DNS",
+			args: args{
+				machines: []machinehandlerpkg.Machine{
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "tigers."}),
+					makeMachine("", corev1.NodeAddress{corev1.NodeInternalDNS, "panda."}),
+				},
+				req: &certificatesv1.CertificateSigningRequest{
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						Usages: []certificatesv1.KeyUsage{
+							certificatesv1.UsageKeyEncipherment,
+							certificatesv1.UsageDigitalSignature,
+							certificatesv1.UsageClientAuth,
+						},
+						Username: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper",
+						Groups: []string{
+							"system:authenticated",
+							"system:serviceaccounts:openshift-machine-config-operator",
+							"system:serviceaccounts",
+						},
+					},
+				},
+				csr: clientGood,
+			},
+			wantErr:   "",
+			authorize: true,
+		},
+		{
 			name: "client extra O",
 			args: args{
 				machines: []machinehandlerpkg.Machine{

--- a/pkg/machinehandler/machinehandler.go
+++ b/pkg/machinehandler/machinehandler.go
@@ -161,7 +161,7 @@ func isMachineCRDPresent(cfg *rest.Config, groupVersion schema.GroupVersion) (bo
 func FindMatchingMachineFromInternalDNS(machines []Machine, nodeName string) (*Machine, error) {
 	for _, machine := range machines {
 		for _, address := range machine.Status.Addresses {
-			if corev1.NodeAddressType(address.Type) == corev1.NodeInternalDNS && strings.EqualFold(address.Address, nodeName) {
+			if corev1.NodeAddressType(address.Type) == corev1.NodeInternalDNS && strings.EqualFold(strings.TrimSuffix(address.Address, "."), nodeName) {
 				return &machine, nil
 			}
 		}


### PR DESCRIPTION
Users may desire to configure their AWS DHCP Option Set with a custom domain name, that contains a trailing dot, but a trailing dot is not permitted in a Kubernetes object name per the DNS 1123 subdomain name standard, so met the bug [OCPBUGS-45306](https://issues.redhat.com/browse/OCPBUGS-45306). We fixed that in the pr https://github.com/openshift/machine-config-operator/pull/4729 to ensure that we trim any trailing dot prior to passing the hostname over to kubelet. 
But a new issue is the client certificates cannot be approved, because we currently look for an exact match (only ignore case) between the node name and the DNS name, and in this case the node name without the trailing dot, but the DNS name with the trailing dot. So update it to ignore the trailing dot when matching.