### PR TITLE
OCPBUGS-45306: Ensure trailing dots on DNS names do not block serving cert auth

### DIFF
--- a/pkg/controller/csr_check.go
+++ b/pkg/controller/csr_check.go
@@ -381,7 +381,7 @@ func authorizeServingCertWithMachine(machines []machinehandlerpkg.Machine, req *
 		for _, addr := range targetMachine.Status.Addresses {
 			switch addr.Type {
 			case corev1.NodeInternalDNS, corev1.NodeExternalDNS, corev1.NodeHostName:
-				if strings.EqualFold(san, addr.Address) {
+				if strings.EqualFold(san, strings.TrimSuffix(addr.Address, ".")) {
 					foundSan = true
 					break
 				} else {

--- a/pkg/controller/csr_check_test.go
+++ b/pkg/controller/csr_check_test.go
@@ -805,6 +805,36 @@ func Test_authorizeCSR(t *testing.T) {
 			authorize: false,
 		},
 		{
+			name: "csr-san-dns-trailing-period",
+			args: args{
+				machines: []machinehandlerpkg.Machine{
+					makeMachine("test", []corev1.NodeAddress{
+						{corev1.NodeInternalIP, "127.0.0.1"},
+						{corev1.NodeExternalIP, "10.0.0.1"},
+						{corev1.NodeExternalDNS, "node1.local."},
+						{corev1.NodeExternalDNS, "node1"},
+					}...),
+				},
+				req: &certificatesv1.CertificateSigningRequest{
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						Usages: []certificatesv1.KeyUsage{
+							certificatesv1.UsageDigitalSignature,
+							certificatesv1.UsageKeyEncipherment,
+							certificatesv1.UsageServerAuth,
+						},
+						Username: "system:node:test",
+						Groups: []string{
+							"system:authenticated",
+							"system:nodes",
+						},
+					},
+				},
+				csr: goodCSR,
+			},
+			wantErr:   "",
+			authorize: true,
+		},
+		{
 			name: "client good",
 			args: args{
 				machines: []machinehandlerpkg.Machine{


### PR DESCRIPTION
This is a follow up to https://github.com/openshift/cluster-machine-approver/pull/248, which fixed the issue for client certificates. However, we also need to fix this for serving certificates so that we can access things like logs or oc debug on the node.