### PR TITLE
OCPCLOUD-2787: Deploy CAPI manifests in CustomNoUpgrade

### DIFF
--- a/manifests/01-rbac-capi.yaml
+++ b/manifests/01-rbac-capi.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
 rules:
 - apiGroups:
   - cluster.x-k8s.io
@@ -29,7 +29,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -10,7 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
We need these manfiests deployed in CustomNoUpgrade as we begin work & testing on the MAPI2CAPI Migration controllers. This will enable e2es to run.