### PR TITLE
NO-JIRA: set machine-approver-controller as default container

### DIFF
--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -22,6 +22,7 @@ spec:
       name: machine-approver-capi
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        kubectl.kubernetes.io/default-container: machine-approver-controller
       labels:
         app: machine-approver-capi
     spec:

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    kubectl.kubernetes.io/default-container: machine-approver-controller
 spec:
   strategy:
     type: Recreate
@@ -22,6 +21,7 @@ spec:
       name: machine-approver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        kubectl.kubernetes.io/default-container: machine-approver-controller
       labels:
         app: machine-approver
     spec:


### PR DESCRIPTION
- As we use `kubectl logs -n openshift-cluster-machine-approver machine-approver-xxxx`, we see the default container logs is `kube-rbac-proxy`, like :

```
Defaulted container "kube-rbac-proxy" out of: kube-rbac-proxy, machine-approver-controller
I0910 05:51:38.746320       1 flags.go:64] FLAG: --add-dir-header="false"
I0910 05:51:38.746472       1 flags.go:64] FLAG: --allow-paths="[]"
I0910 05:51:38.746479       1 flags.go:64] FLAG: --alsologtostderr="false"
I0910 05:51:38.746481       1 flags.go:64] FLAG: --auth-header-fields-enabled="false"
I0910 05:51:38.746483       1 flags.go:64] FLAG: --auth-header-groups-field-name="x-remote-groups"
I0910 05:51:38.746487       1 flags.go:64] FLAG: --auth-header-groups-field-separator="|"
I0910 05:51:38.746489       1 flags.go:64] FLAG: --auth-header-user-field-name="x-remote-user"
I0910 05:51:38.746492       1 flags.go:64] FLAG: --auth-token-audiences="[]"
I0910 05:51:38.746497       1 flags.go:64] FLAG: --client-ca-file=""
I0910 05:51:38.746499       1 flags.go:64] FLAG: --config-file="/etc/kube-rbac-proxy/config-file.yaml"
I0910 05:51:38.746501       1 flags.go:64] FLAG: --help="false"
I0910 05:51:38.746503       1 flags.go:64] FLAG: --http2-disable="false"
I0910 05:51:38.746505       1 flags.go:64] FLAG: --http2-max-concurrent-streams="100"
I0910 05:51:38.746508       1 flags.go:64] FLAG: --http2-max-size="262144"
I0910 05:51:38.746511       1 flags.go:64] FLAG: --ignore-paths="[]"
I0910 05:51:38.746515       1 flags.go:64] FLAG: --insecure-listen-address=""
I0910 05:51:38.746516       1 flags.go:64] FLAG: --kube-api-burst="0"
I0910 05:51:38.746520       1 flags.go:64] FLAG: --kube-api-qps="0"
I0910 05:51:38.746523       1 flags.go:64] FLAG: --kubeconfig=""
I0910 05:51:38.746525       1 flags.go:64] FLAG: --log-backtrace-at=""
I0910 05:51:38.746527       1 flags.go:64] FLAG: --log-dir=""
I0910 05:51:38.746529       1 flags.go:64] FLAG: --log-file=""
I0910 05:51:38.746531       1 flags.go:64] FLAG: --log-file-max-size="0"
I0910 05:51:38.746534       1 flags.go:64] FLAG: --log-flush-frequency="5s"
I0910 05:51:38.746539       1 flags.go:64] FLAG: --logtostderr="true"
I0910 05:51:38.746541       1 flags.go:64] FLAG: --oidc-ca-file=""
I0910 05:51:38.746543       1 flags.go:64] FLAG: --oidc-clientID=""
I0910 05:51:38.746545       1 flags.go:64] FLAG: --oidc-groups-claim="groups"
I0910 05:51:38.746547       1 flags.go:64] FLAG: --oidc-groups-prefix=""
I0910 05:51:38.746549       1 flags.go:64] FLAG: --oidc-issuer=""
I0910 05:51:38.746551       1 flags.go:64] FLAG: --oidc-sign-alg="[RS256]"
I0910 05:51:38.746564       1 flags.go:64] FLAG: --oidc-username-claim="email"
I0910 05:51:38.746567       1 flags.go:64] FLAG: --one-output="false"
I0910 05:51:38.746568       1 flags.go:64] FLAG: --proxy-endpoints-port="0"
I0910 05:51:38.746571       1 flags.go:64] FLAG: --secure-listen-address="0.0.0.0:9192"
I0910 05:51:38.746573       1 flags.go:64] FLAG: --skip-headers="false"
I0910 05:51:38.746575       1 flags.go:64] FLAG: --skip-log-headers="false"
I0910 05:51:38.746576       1 flags.go:64] FLAG: --stderrthreshold=""
I0910 05:51:38.746578       1 flags.go:64] FLAG: --tls-cert-file="/etc/tls/private/tls.crt"
I0910 05:51:38.746580       1 flags.go:64] FLAG: --tls-cipher-suites="[TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305]"
I0910 05:51:38.746588       1 flags.go:64] FLAG: --tls-min-version="VersionTLS12"
I0910 05:51:38.746591       1 flags.go:64] FLAG: --tls-private-key-file="/etc/tls/private/tls.key"
I0910 05:51:38.746595       1 flags.go:64] FLAG: --tls-reload-interval="1m0s"
I0910 05:51:38.746599       1 flags.go:64] FLAG: --upstream="http://127.0.0.1:9191/"
I0910 05:51:38.746601       1 flags.go:64] FLAG: --upstream-ca-file=""
I0910 05:51:38.746603       1 flags.go:64] FLAG: --upstream-client-cert-file=""
I0910 05:51:38.746605       1 flags.go:64] FLAG: --upstream-client-key-file=""
I0910 05:51:38.746606       1 flags.go:64] FLAG: --upstream-force-h2c="false"
I0910 05:51:38.746608       1 flags.go:64] FLAG: --v="3"
I0910 05:51:38.746610       1 flags.go:64] FLAG: --version="false"
I0910 05:51:38.746614       1 flags.go:64] FLAG: --vmodule=""
W0910 05:51:38.746619       1 deprecated.go:66] 
==== Removed Flag Warning ======================

logtostderr is removed in the k8s upstream and has no effect any more.

===============================================

I0910 05:51:38.746639       1 kube-rbac-proxy.go:530] Reading config file: /etc/kube-rbac-proxy/config-file.yaml
I0910 05:51:38.747266       1 kube-rbac-proxy.go:233] Valid token audiences: 
I0910 05:51:38.747307       1 kube-rbac-proxy.go:347] Reading certificate files
I0910 05:51:38.747686       1 kube-rbac-proxy.go:395] Starting TCP socket on 0.0.0.0:9192
I0910 05:51:38.748029       1 kube-rbac-proxy.go:402] Listening securely on 0.0.0.0:9192
```

- But most of the time we just care about the container `machine-approver-controller` logs , not the `kube-rbac-proxy`
- And I noticed that the https://github.com/openshift/cluster-machine-approver/pull/163 has also tried to set the default container, but i'm afraid it set the wrong place
- When I set unmanaged configuration for the deployment in cvo, and add this `kubectl.kubernetes.io/default-container: machine-approver-controller` annotation, the default logs change to `machine-approver-controller`, like :
```
kubectl logs -n openshift-cluster-machine-approver machine-approver-xxxxx 
W0915 01:29:31.356216       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0915 01:29:31.356515       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0915 01:29:31.356616       1 main.go:150] setting up manager
I0915 01:29:31.356933       1 main.go:168] registering components
I0915 01:29:31.356947       1 main.go:170] setting up scheme
I0915 01:29:31.357239       1 main.go:208] setting up controllers
I0915 01:29:31.357273       1 config.go:33] using default as failed to load config /var/run/configmaps/config/config.yaml: open /var/run/configmaps/config/config.yaml: no such file or directory
I0915 01:29:31.357283       1 config.go:23] machine approver config: {NodeClientCert:{Disabled:false}}
I0915 01:29:31.357419       1 main.go:233] starting the cmd
I0915 01:29:31.357591       1 server.go:185] "Starting metrics server" logger="controller-runtime.metrics"
```