### PR TITLE
OCPBUGS-65484: Add debug-useful ClusterOperator relatedObjects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,5 +118,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
+	sigs.k8s.io/yaml v1.6.0
 )

--- a/manifests/05-clusteroperator.yaml
+++ b/manifests/05-clusteroperator.yaml
@@ -10,11 +10,39 @@ spec: {}
 status:
   relatedObjects:
   - group: ""
-    name: openshift-cluster-machine-approver
     resource: namespaces
+    name: openshift-cluster-machine-approver
   - group: certificates.k8s.io
-    name: ""
     resource: certificatesigningrequests
+    name: ""
+  - group: rbac.authorization.k8s.io
+    resource: clusterroles
+    name: system:openshift:controller:machine-approver
+  - group: rbac.authorization.k8s.io
+    resource: clusterroles
+    name: system:openshift:controller:machine-approver-capi
+  - group: rbac.authorization.k8s.io
+    resource: clusterrolebindings
+    name: system:openshift:controller:machine-approver
+  - group: rbac.authorization.k8s.io
+    resource: clusterrolebindings
+    name: system:openshift:controller:machine-approver-capi
+  - group: rbac.authorization.k8s.io
+    resource: roles
+    namespace: openshift-config-managed
+    name: machine-approver
+  - group: rbac.authorization.k8s.io
+    resource: rolebindings
+    namespace: openshift-config-managed
+    name: machine-approver
+  - group: rbac.authorization.k8s.io
+    resource: roles
+    namespace: openshift-cluster-machine-approver
+    name: ""
+  - group: rbac.authorization.k8s.io
+    resource: rolebindings
+    namespace: openshift-cluster-machine-approver
+    name: ""
   versions:
     - name: operator
       version: "0.0.1-snapshot"

--- a/related_objects_test.go
+++ b/related_objects_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	osconfigv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("relatedObjects", func() {
+	It("should stay in sync with the ClusterOperator manifest", func() {
+		manifestPath := filepath.Join("manifests", "05-clusteroperator.yaml")
+		data, err := os.ReadFile(manifestPath)
+		Expect(err).ToNot(HaveOccurred(), "should be able to read ClusterOperator manifest")
+
+		co := &osconfigv1.ClusterOperator{}
+		Expect(yaml.Unmarshal(data, co)).To(Succeed(), "should be able to unmarshal ClusterOperator manifest")
+
+		Expect(co.Status.RelatedObjects).To(Equal(relatedObjects), "Go relatedObjects must match the static ClusterOperator manifest")
+	})
+})

--- a/status.go
+++ b/status.go
@@ -46,6 +46,50 @@ var relatedObjects = []osconfigv1.ObjectReference{
 		Resource: "certificatesigningrequests",
 		Name:     "",
 	},
+	{
+		Group:    "rbac.authorization.k8s.io",
+		Resource: "clusterroles",
+		Name:     "system:openshift:controller:machine-approver",
+	},
+	{
+		Group:    "rbac.authorization.k8s.io",
+		Resource: "clusterroles",
+		Name:     "system:openshift:controller:machine-approver-capi",
+	},
+	{
+		Group:    "rbac.authorization.k8s.io",
+		Resource: "clusterrolebindings",
+		Name:     "system:openshift:controller:machine-approver",
+	},
+	{
+		Group:    "rbac.authorization.k8s.io",
+		Resource: "clusterrolebindings",
+		Name:     "system:openshift:controller:machine-approver-capi",
+	},
+	{
+		Group:     "rbac.authorization.k8s.io",
+		Resource:  "roles",
+		Namespace: "openshift-config-managed",
+		Name:      "machine-approver",
+	},
+	{
+		Group:     "rbac.authorization.k8s.io",
+		Resource:  "rolebindings",
+		Namespace: "openshift-config-managed",
+		Name:      "machine-approver",
+	},
+	{
+		Group:     "rbac.authorization.k8s.io",
+		Resource:  "roles",
+		Namespace: clusterOperatorNamespace,
+		Name:      "",
+	},
+	{
+		Group:     "rbac.authorization.k8s.io",
+		Resource:  "rolebindings",
+		Namespace: clusterOperatorNamespace,
+		Name:      "",
+	},
 }
 
 type statusController struct {


### PR DESCRIPTION
Expand `machine-approver` ClusterOperator `relatedObjects` with RBAC that namespace inspect does not collect.

Keeps the existing namespace and CertificateSigningRequests entries.

## Added relatedObjects
- ClusterRoles / ClusterRoleBindings: `system:openshift:controller:machine-approver`, `system:openshift:controller:machine-approver-capi`
- Role / RoleBinding: `machine-approver` in `openshift-config-managed`
- Roles / RoleBindings in `openshift-cluster-machine-approver`

## Tests
Parity test keeping the Go list in sync with the ClusterOperator manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClusterOperator status reporting by including all relevant machine approver RBAC resources.
  * Added references for controller roles, bindings, and namespace-scoped permissions.

* **Tests**
  * Added validation to keep reported related resources consistent between deployment configuration and runtime status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->