### PR TITLE
NO-JIRA: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
@@ -28,7 +28,7 @@ func LoadConfig(cliConfig string) ClusterMachineApproverConfig {
 		return config
 	}
 
-	content, err := ioutil.ReadFile(cliConfig)
+	content, err := os.ReadFile(cliConfig)
 	if err != nil {
 		klog.Infof("using default as failed to load config %s: %v", cliConfig, err)
 		return config


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

- Modernized file reading by switching from `ioutil.ReadFile` to `os.ReadFile` in `pkg/controller/config.go`, aligning with current Go best practices. [[1]](diffhunk://#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75L5-R5) [[2]](diffhunk://#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75L31-R31)