### PR TITLE
NO-JIRA: fix: add pod annotation: openshift.io/required-scc: restricted-v2

### DIFF
--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         kubectl.kubernetes.io/default-container: machine-approver-controller
+        openshift.io/required-scc: restricted-v2
       labels:
         app: machine-approver-capi
     spec:

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         kubectl.kubernetes.io/default-container: machine-approver-controller
+        openshift.io/required-scc: restricted-v2
       labels:
         app: machine-approver
     spec:


### PR DESCRIPTION
The openshift.io/required-scc: restricted-v2 annotation should be set on
pods as required by the [requiredSCCAnnotationChecker](https://github.com/openshift/origin/blob/d7ad0db6b652a27b8e7d547dcca79a5e00be7d08/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L85-L87)

more info on scc: 
- https://github.com/openshift/openshift-docs/blob/72420d78d324c3088372ec7c508d933864181336/modules/security-context-constraints-requiring.adoc#L26
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/authentication_and_authorization/managing-pod-security-policies#security-context-constraints-about_configuring-internal-oauth
