### PR TITLE
NO-JIRA: Deploy cluster-machine-approver without host networking

### DIFF
--- a/manifests/03-metrics-service.yaml
+++ b/manifests/03-metrics-service.yaml
@@ -34,7 +34,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: machine-approver-capi-tls
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
   labels:
     app: machine-approver-capi
 spec:

--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -26,7 +26,6 @@ spec:
       labels:
         app: machine-approver-capi
     spec:
-      hostNetwork: true
       serviceAccountName: machine-approver-sa
       containers:
       - name: machine-approver-controller

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -25,7 +25,6 @@ spec:
       labels:
         app: machine-approver
     spec:
-      hostNetwork: true
       serviceAccountName: machine-approver-sa
       containers:
       - name: machine-approver-controller


### PR DESCRIPTION
Deploys the MAPI and CAPI CMA deployments without host networking. CMA does not
appear to need host networking: the bootstrap node will approve the control
plane nodes, which then don't need CMA to fully initialise. CMA can therefore
run normally once the control plane is initialised.

There was some discussion as to whether this might be to cover the
'hibernation' case where a cluster has been down long enough that Node certs
will have expired. This might be an argument for it to use host networking, but
in that case CMA would have to also be a static pod for kubelet to start it
without control plane access, and the CSR approver would no longer be required
on the bootstrap node.

It was originally added in https://github.com/openshift/cluster-machine-approver/pull/7

Also updates the CAPI deployment to gate on the ClusterAPIMachineManagement
feature gate instead of TechPreviewNoUpgrade.

/hold for discussion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feature management configuration for improved OpenShift compatibility.
  * Disabled host networking in deployments to enhance network isolation and security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->