### PR TITLE
OCPBUGS-86772: fix: use feature-gate annotation for CAPI manifests

### DIFF
--- a/manifests/01-rbac-capi.yaml
+++ b/manifests/01-rbac-capi.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
 rules:
 - apiGroups:
   - cluster.x-k8s.io
@@ -29,7 +29,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -10,7 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
## Summary
- Replace `release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"` with `release.openshift.io/feature-gate: "ClusterAPIMachineManagement"` across all CAPI manifests (`01-rbac-capi.yaml`, `04-deployment-capi.yaml`)
- Aligns with the approach used by [cluster-capi-operator](https://github.com/openshift/cluster-capi-operator/blob/778c90dd8de9de8597c3ef0618ef0fbd41125a87/manifests/0000_30_cluster-api-installer_01_serviceaccount.yaml#L11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feature gate configuration for Cluster API Machine Management across deployment and RBAC manifests. Replaced previous feature set annotations with the new `ClusterAPIMachineManagement` feature gate designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->