### PR TITLE
OCPBUGS-84521: set terminationMessagePolicy on kube-rbac-proxy

### DIFF
--- a/manifests/04-deployment-capi.yaml
+++ b/manifests/04-deployment-capi.yaml
@@ -45,8 +45,7 @@ spec:
         - containerPort: 9194
           name: https
           protocol: TCP
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
             memory: 20Mi


### PR DESCRIPTION
> [!IMPORTANT]  
> I am waiting for the https://github.com/openshift/origin/pull/31362 to be merged so that I can perform the Jira steps for the CI bot in this repo to accept this PR.

## Summary

Set `terminationMessagePolicy: FallbackToLogsOnError` on the `kube-rbac-proxy` container in the CAPI deployment. It was set to `File`, causing CI flakes in `[Monitor:termination-message-policy][sig-arch] all containers in ns/openshift-cluster-machine-approver`.

## Additional Info

On main this was fixed by removing kube-rbac-proxy entirely (https://github.com/openshift/cluster-machine-approver/commit/545d7e4883). On release-4.22 the sidecar is still needed, so we fix the policy instead.

Related: https://github.com/openshift/origin/pull/31362 (removes the stale exemption for this namespace on main in openshift/origin)

Cherry-picking to release-4.21, release-4.20, and release-4.19. Not going further back as this is a Normal priority fix.

Fixes: https://issues.redhat.com/browse/OCPBUGS-84521