### PR TITLE
OCPBUGS-100160: Fix status controller unit-test teardown race

### DIFF
--- a/status.go
+++ b/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
@@ -95,8 +96,15 @@ func (c *statusController) runWorker() {
 func (c *statusController) Run(threadiness int, stopCh chan struct{}) {
 	defer utilruntime.HandleCrash()
 
-	// Let the workers stop when we are done
-	defer c.queue.ShutDown()
+	// Shut down the queue then wait for workers on every exit path (cache-sync
+	// failure or stopCh) so an in-flight sync cannot recreate ClusterOperator
+	// state after Run returns.
+	var wg sync.WaitGroup
+	defer func() {
+		c.queue.ShutDown()
+		wg.Wait()
+	}()
+
 	klog.Info("Starting cluster operator status controller")
 
 	go c.clusterOperatorInformer.Run(stopCh)
@@ -110,7 +118,11 @@ func (c *statusController) Run(threadiness int, stopCh chan struct{}) {
 	go c.watchVersionGetter(stopCh)
 
 	for i := 0; i < threadiness; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wait.Until(c.runWorker, time.Second, stopCh)
+		}()
 	}
 
 	<-stopCh
@@ -191,7 +203,7 @@ func (c *statusController) statusAvailable() error {
 			Status:             osconfigv1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
 			Reason:             reasonAsExpected,
-			Message:            fmt.Sprintf("Cluster Machine Approver is available at %s", c.versionGetter.GetVersions()["operator"]),
+			Message:            fmt.Sprintf("Cluster Machine Approver is available at %s", c.operatorVersion()),
 		},
 		{
 			Type:               osconfigv1.OperatorDegraded,
@@ -216,8 +228,15 @@ func (c *statusController) statusAvailable() error {
 		},
 	}
 
-	co.Status.Versions = []osconfigv1.OperandVersion{{Name: "operator", Version: getReleaseVersion()}}
+	co.Status.Versions = []osconfigv1.OperandVersion{{Name: operatorVersionKey, Version: c.operatorVersion()}}
 	return c.syncStatus(co, conds)
+}
+
+func (c *statusController) operatorVersion() string {
+	if version := c.versionGetter.GetVersions()[operatorVersionKey]; len(version) > 0 {
+		return version
+	}
+	return getReleaseVersion()
 }
 
 func (c *statusController) getOrCreateClusterOperator() (*osconfigv1.ClusterOperator, error) {

--- a/status_test.go
+++ b/status_test.go
@@ -122,15 +122,17 @@ var _ = Describe("Cluster Operator status controller", func() {
 			close(startController) // Ensure that existingCO is created before starting the statusController.
 
 			var co *osconfigv1.ClusterOperator
-			Eventually(func() (bool, error) {
+			Eventually(func() (string, error) {
 				var err error
 				co, err = osClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
 				if err != nil {
-					return false, err
+					return "", err
 				}
-				// Successful sync means CO exists and the status is not empty
-				return len(co.Status.Versions) > 0, nil
-			}, timeout).Should(BeTrue())
+				if len(co.Status.Versions) == 0 {
+					return "", nil
+				}
+				return co.Status.Versions[0].Version, nil
+			}, timeout).Should(Equal(expectedVersion))
 
 			// check version.
 			Expect(co.Status.Versions).To(HaveLen(1))


### PR DESCRIPTION
## Summary

### Cause
With `--randomize-all`, a status-controller case that leaves `RELEASE_VERSION` unset can return from `Run` while a queue worker is still inside `statusAvailable`. That lingering sync recreates/updates the ClusterOperator as `unknown` after the next case has already started. The suite's `Eventually` only required a non-empty `Versions` slice, so it accepted the stale value.

### Consequence
Unrelated PRs flake on `ci/prow/unit` in ~9ms with `Expected unknown to equal a_cvo_given_version`:
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-machine-approver/310/pull-ci-openshift-cluster-machine-approver-main-unit/2082042738303307776
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-machine-approver/304/pull-ci-openshift-cluster-machine-approver-main-unit/2059912951690694656

### Fix
- On stop: `queue.ShutDown()` then `WaitGroup.Wait()` so workers finish before `Run` returns; also `ShutDown` on the cache-sync early-return path.
- Prefer `versionGetter` for `Versions` (fallback to `RELEASE_VERSION`) so status matches the Available / `SetVersion` path.
- `Eventually` waits until `Versions[0].Version == expectedVersion`.

### Result
Cross-case CO writes after teardown are blocked, and a stale non-empty `Versions` slice can no longer false-pass the suite.

## Context & Patterns

**Why WaitGroup after ShutDown, not just defer ShutDown** — Closing `stopCh` used to shut down the queue and return from `Run` while a worker could still be inside `statusAvailable`. In the suite, `AfterEach` treats `Run` return as "idle" and deletes the ClusterOperator; a late sync then recreates it as `unknown` for the next case. Shutting down the queue first, then waiting on workers, makes "controller stopped" mean no further CO writes.

**Why Eventually asserts the exact version** — With `--randomize-all`, a prior case that left `RELEASE_VERSION` unset can leave a stale non-empty `Versions` slice. Waiting only for `len(Versions) > 0` accepts that stale `unknown` in a few milliseconds. Waiting for `Versions[0].Version == expectedVersion` turns cross-case contamination into a timeout instead of a false pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cluster operator status controller’s shutdown behavior to ensure background workers complete cleanly.
  * Enhanced cluster operator status version reporting to prefer the configured operator version when available, with a fallback to the release version.
  * Made operator availability/status messaging consistently reflect the computed operator version.
* **Tests**
  * Updated status tests to repeatedly verify the reported cluster operator version matches the expected value before asserting success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->