### PR TITLE
OCPBUGS-99489: Add NetworkPolicy manifests to openshift-cluster-machine-approver namespace

### DIFF
--- a/manifests/06-networkpolicy-allow-all-egress.yaml
+++ b/manifests/06-networkpolicy-allow-all-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-egress
+  namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  egress:
+  - {}
+  policyTypes:
+  - Egress

--- a/manifests/06-networkpolicy-allow-ingress-metrics.yaml
+++ b/manifests/06-networkpolicy-allow-ingress-metrics.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-metrics
+  namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - machine-approver
+      - machine-approver-capi
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9192
+    - protocol: TCP
+      port: 9194
+  policyTypes:
+  - Ingress

--- a/manifests/06-networkpolicy-default-deny.yaml
+++ b/manifests/06-networkpolicy-default-deny.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cluster-machine-approver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
The namespace was missing network policies.  Adds default-deny, allow-all-egress, and allow-ingress for metrics scraping on ports 9192 and 9194.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network security policies for the machine approver service.
  * Restricted inbound metrics traffic to designated monitoring ports.
  * Added default-deny rules for inbound and outbound traffic, with approved outbound access enabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->