### PR TITLE
NO-JIRA: Bump envtest to 1.36.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.34.1
+ENVTEST_K8S_VERSION = 1.36.2
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ENVTEST = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest


### PR DESCRIPTION
Update envtest to 1.36.2 to match the K8s 1.36 upgrade in #311.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubernetes test environment version used by automated unit testing.
  * Aligns test execution with the newer Kubernetes 1.36.2 environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->